### PR TITLE
Issue 9

### DIFF
--- a/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/BaseCommitStatusSettings.java
+++ b/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/BaseCommitStatusSettings.java
@@ -1,0 +1,68 @@
+package org.jetbrains.teamcity.publisher;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public abstract class BaseCommitStatusSettings implements CommitStatusPublisherSettings {
+    @Override
+    @Nullable
+    public Collection<String> getMandatoryParameters() {
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public Map<String, String> getDefaultParameters() {
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public Map<String, String> getParameterUpgrades(@NotNull Map<String, String> params) {
+        Map<String, String> paramChanges = new HashMap<String, String>();
+        Map<String, String> defaultParams = getDefaultParameters();
+        Collection<String> mandatoryParams = getMandatoryParameters();
+
+        // Are we missing a mandatory parameter that we know a default value for?
+        if (mandatoryParams != null && defaultParams != null) {
+            for (String paramName : mandatoryParams) {
+                if (!params.containsKey(paramName) && defaultParams.containsKey(paramName)) {
+                    paramChanges.put(paramName, defaultParams.get(paramName));
+                }
+            }
+        }
+
+        if (paramChanges.isEmpty()) {
+            return null;
+        }
+        return paramChanges;
+    }
+
+    /**
+     * Inject new mandatory properties into an existing property list before
+     * creating a publisher instance.
+     *
+     * This is necessary for properties that have been added to our code since
+     * the properties for a specific Build Feature instance were first created
+     * by the user.
+     */
+
+    @NotNull
+    protected Map<String, String> getUpdatedParametersForPublisher(@NotNull final Map<String, String> params) {
+        Map<String, String> updates = getParameterUpgrades(params);
+        if (updates == null) {
+            return params;
+        }
+
+        // Note that the supplied `params` map is unmodifiable.
+        Map<String, String> updatedParams = new HashMap<String, String>(params);
+
+        for (Map.Entry<String, String> update: updates.entrySet()) {
+            updatedParams.put(update.getKey(), update.getValue());
+        }
+
+        return updatedParams;
+    }
+}

--- a/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/CommitStatusPublisherSettings.java
+++ b/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/CommitStatusPublisherSettings.java
@@ -4,6 +4,7 @@ import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Map;
 
 public interface CommitStatusPublisherSettings {
@@ -17,8 +18,28 @@ public interface CommitStatusPublisherSettings {
   @Nullable
   String getEditSettingsUrl();
 
+  /**
+   * Get the names of any parameters that must be set.
+   */
+  @Nullable
+  Collection<String> getMandatoryParameters();
+
   @Nullable
   Map<String, String> getDefaultParameters();
+
+  /**
+   * Get any changes necessary to make the supplied parameters valid.
+   *
+   * The supplied parameters map is not changed.
+   *
+   * There may not always be a known update for an invalid parameter, so the
+   * parameters could still be invalid after applying the changes.
+   *
+   * @param params
+   * @return Only the *changes* we need to make to params (if any).
+   */
+  @Nullable
+  Map<String, String> getParameterUpgrades(@NotNull Map<String, String> params);
 
   @Nullable
   CommitStatusPublisher createPublisher(@NotNull Map<String, String> params);

--- a/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/DummyPublisherSettings.java
+++ b/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/DummyPublisherSettings.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
-public class DummyPublisherSettings implements CommitStatusPublisherSettings {
+public class DummyPublisherSettings extends BaseCommitStatusSettings  {
   public static final String ID = "--";
 
   @NotNull
@@ -26,11 +26,6 @@ public class DummyPublisherSettings implements CommitStatusPublisherSettings {
 
   @Nullable
   public CommitStatusPublisher createPublisher(@NotNull Map<String, String> params) {
-    return null;
-  }
-
-  @Nullable
-  public Map<String, String> getDefaultParameters() {
     return null;
   }
 

--- a/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/gerrit/GerritPublisher.java
+++ b/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/gerrit/GerritPublisher.java
@@ -47,7 +47,7 @@ public class GerritPublisher extends BaseCommitStatusPublisher {
 
     StringBuilder command = new StringBuilder();
     command.append("gerrit review --project ").append(getGerritProject())
-           .append(" --verified ").append(vote)
+           .append(" --label ").append(getGerritLabel()).append("=").append(vote)
            .append(" -m \"").append(msg).append("\" ")
            .append(revision.getRevision());
     try {
@@ -122,6 +122,10 @@ public class GerritPublisher extends BaseCommitStatusPublisher {
 
   private String getUsername() {
     return myParams.get("gerritUsername");
+  }
+
+  private String getGerritLabel() {
+    return myParams.get("gerritLabel");
   }
 
   private String getSuccessVote() {

--- a/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/gerrit/GerritSettings.java
+++ b/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/gerrit/GerritSettings.java
@@ -49,6 +49,7 @@ public class GerritSettings extends BaseCommitStatusSettings {
     params.add("gerritServer");
     params.add("gerritProject");
     params.add("gerritUsername");
+    params.add("gerritLabel");
     params.add("successVote");
     params.add("failureVote");
     params.add(TEAMCITY_SSH_KEY_PROP);
@@ -59,6 +60,7 @@ public class GerritSettings extends BaseCommitStatusSettings {
   @Nullable
   public Map<String, String> getDefaultParameters() {
     Map<String, String> params = new HashMap<String, String>();
+    params.put("gerritLabel", "Verified");
     params.put("successVote", "+1");
     params.put("failureVote", "-1");
     return params;

--- a/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/github/GitHubSettings.java
+++ b/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/github/GitHubSettings.java
@@ -6,8 +6,8 @@ import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import jetbrains.buildServer.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.teamcity.publisher.BaseCommitStatusSettings;
 import org.jetbrains.teamcity.publisher.CommitStatusPublisher;
-import org.jetbrains.teamcity.publisher.CommitStatusPublisherSettings;
 import org.jetbrains.teamcity.publisher.github.api.GitHubApiAuthenticationType;
 import org.jetbrains.teamcity.publisher.github.api.GitHubApiFactory;
 import org.jetbrains.teamcity.publisher.github.ui.UpdateChangesConstants;
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GitHubSettings implements CommitStatusPublisherSettings {
+public class GitHubSettings extends BaseCommitStatusSettings {
 
   private final ChangeStatusUpdater myUpdater;
 
@@ -50,6 +50,7 @@ public class GitHubSettings implements CommitStatusPublisherSettings {
 
   @Nullable
   public CommitStatusPublisher createPublisher(@NotNull Map<String, String> params) {
+    params = getUpdatedParametersForPublisher(params);
     return new GitHubPublisher(myUpdater, params);
   }
 

--- a/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/stash/StashSettings.java
+++ b/commit-status-publisher-server/src/main/java/org/jetbrains/teamcity/publisher/stash/StashSettings.java
@@ -6,15 +6,16 @@ import jetbrains.buildServer.serverSide.WebLinks;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.teamcity.publisher.BaseCommitStatusSettings;
 import org.jetbrains.teamcity.publisher.CommitStatusPublisher;
-import org.jetbrains.teamcity.publisher.CommitStatusPublisherSettings;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class StashSettings implements CommitStatusPublisherSettings {
+public class StashSettings extends BaseCommitStatusSettings {
 
   private final PluginDescriptor myDescriptor;
   private final WebLinks myLinks;
@@ -41,12 +42,8 @@ public class StashSettings implements CommitStatusPublisherSettings {
   }
 
   @Nullable
-  public Map<String, String> getDefaultParameters() {
-    return null;
-  }
-
-  @Nullable
   public CommitStatusPublisher createPublisher(@NotNull Map<String, String> params) {
+    params = getUpdatedParametersForPublisher(params);
     return new StashPublisher(myLinks, params);
   }
 
@@ -54,6 +51,14 @@ public class StashSettings implements CommitStatusPublisherSettings {
   public String describeParameters(@NotNull Map<String, String> params) {
     StashPublisher voter = (StashPublisher) createPublisher(params);
     return "Atlassian Stash " + voter.getBaseUrl();
+  }
+
+  @Nullable
+  public Collection<String> getMandatoryParameters() {
+    final List<String> params = new ArrayList<String>();
+    params.add("stashBaseUrl");
+
+    return Collections.unmodifiableList(params);
   }
 
   @Nullable

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/gerrit/gerritSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/gerrit/gerritSettings.jsp
@@ -31,6 +31,14 @@
   </tr>
 
   <tr>
+    <th><label for="gerritLabel">Gerrit label: <l:star/></label></th>
+    <td>
+      <props:textProperty name="gerritLabel" style="width:18em;"/>
+      <span class="error" id="error_gerritLabel"></span>
+    </td>
+  </tr>
+
+  <tr>
     <th><label for="successVote">Successful build vote: <l:star/></label></th>
     <td>
       <props:textProperty name="successVote" style="width:18em;"/>


### PR DESCRIPTION
Implementation of issue #9.

1. Add some scaffolding to upgrade outdated plugin parameters on the fly. I didn't know if there's a better way to do this (eg. update the parmeters in storage when TeamCity or the plugin are instantiated).
1. Add a new compulsory parameter for the Gerrit Label, as suggested in #9, and use it in place of `--verified`.