### PR TITLE
Display "required parameter" stars in a consistent way.

### DIFF
--- a/commit-status-publisher-server/src/main/resources/buildServerResources/github/githubSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/github/githubSettings.jsp
@@ -23,7 +23,7 @@
 
     <props:selectSectionPropertyContent value="${keys.authenticationTypePasswordValue}" caption="Password">
       <tr>
-        <th>User Name<l:star/>:</th>
+        <th>User Name: <l:star/></th>
         <td>
           <props:textProperty name="${keys.userNameKey}" className="longField"/>
           <span class="error" id="error_${keys.userNameKey}"></span>
@@ -31,7 +31,7 @@
         </td>
       </tr>
       <tr>
-        <th>Password<l:star/>:</th>
+        <th>Password: <l:star/></th>
         <td>
           <props:passwordProperty name="${keys.passwordKey}" className="longField"/>
           <span class="error" id="error_${keys.passwordKey}"></span>
@@ -42,7 +42,7 @@
 
     <props:selectSectionPropertyContent value="${keys.authenticationTypeTokenValue}" caption="Access Token">
       <tr>
-        <th>Personal Access Token<l:star/>:</th>
+        <th>Personal Access Token: <l:star/></th>
         <td>
           <props:passwordProperty name="${keys.accessTokenKey}" className="longField"/>
           <span class="error" id="error_${keys.accessTokenKey}"></span>
@@ -59,7 +59,7 @@
   </props:selectSectionProperty>
 
   <tr>
-    <th>URL:<l:star/></th>
+    <th>URL: <l:star/></th>
     <td>
       <props:textProperty name="${keys.serverKey}" className="longField"/>
       <span class="error" id="error_${keys.serverKey}"></span>


### PR DESCRIPTION
Most of our parameter entry screens display required parameters as
`Some parameter: *`. Make the github parameters consistent with this
format