### PR TITLE
Accept MappingID for projects hosted in multiple repositories (Upsource)

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
@@ -17,6 +17,7 @@ public class Constants {
   public static final String UPSOURCE_PUBLISHER_ID = "upsourcePublisher";
   public static final String UPSOURCE_SERVER_URL = "upsourceServerUrl";
   public static final String UPSOURCE_PROJECT_ID = "upsourceProjectId";
+  public static final String UPSOURCE_MAPPING_ID = "upsourceMappingId";
   public static final String UPSOURCE_USERNAME = "upsourceUsername";
   public static final String UPSOURCE_PASSWORD = "secure:upsourcePassword";
 
@@ -61,6 +62,11 @@ public class Constants {
   @NotNull
   public String getUpsourceProjectId() {
     return UPSOURCE_PROJECT_ID;
+  }
+
+  @NotNull
+  public String getUpsourceMappingId() {
+    return UPSOURCE_MAPPING_ID;
   }
 
   @NotNull

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/upsource/UpsourcePublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/upsource/UpsourcePublisher.java
@@ -147,7 +147,7 @@ public class UpsourcePublisher extends BaseCommitStatusPublisher {
   @NotNull
   private String getRevision(@NotNull BuildRevision revision) {
     String mappingID = myParams.get(Constants.UPSOURCE_MAPPING_ID);
-    if(mappingID.length() > 0)
+    if(mappingID != null && mappingID.length() > 0)
     {
       return mappingID+'-'+revision.getRevision();
     }

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/upsource/UpsourcePublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/upsource/UpsourcePublisher.java
@@ -133,7 +133,7 @@ public class UpsourcePublisher extends BaseCommitStatusPublisher {
             buildName,
             url,
             description,
-            revision.getRevision(),
+            getRevision(revision),
             commitMessage,
             commitDate);
     try {
@@ -142,6 +142,17 @@ public class UpsourcePublisher extends BaseCommitStatusPublisher {
       throw new PublishError("Cannot publish status to Upsource for VCS root " +
               revision.getRoot().getName() + ": " + e.toString(), e);
     }
+  }
+
+  @NotNull
+  private String getRevision(@NotNull BuildRevision revision) {
+    String mappingID = myParams.get(Constants.UPSOURCE_MAPPING_ID);
+    if(mappingID.length() > 0)
+    {
+      return mappingID+'-'+revision.getRevision();
+    }
+
+    return revision.getRevision();
   }
 
 

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/upsource/upsourceSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/upsource/upsourceSettings.jsp
@@ -24,6 +24,14 @@
     </tr>
 
     <tr>
+        <th><label for="${keys.upsourceMappingId}">Upsource mapping ID:</label></th>
+        <td>
+            <props:textProperty name="${keys.upsourceMappingId}" style="width:18em;"/>
+            <span class="error" id="error_${keys.upsourceMappingId}"></span>
+        </td>
+    </tr>
+
+    <tr>
         <th><label for="${keys.upsourceUsername}">Username: <l:star/></label></th>
         <td>
             <props:textProperty name="${keys.upsourceUsername}" style="width:18em;"/>


### PR DESCRIPTION
In Upsource other repositories can be mounted as subfolders. In order to allow TeamCity provide build informationen for mounted repositories, Upsource requires a MappingID as prefix to the revision number.
Upsource expects for mounted repositories the revision number in the following format {MAPPING_ID}-{REVISION_ID}.

If you choose "JetBrains Upsource" in TeamCity as an commit status publisher, a new field "Upsource mapping ID" should be provided. Here you can enter the "Mapping ID" from Upsource. 