### PR TITLE
GitLab improvements

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
@@ -26,14 +26,11 @@ public class GitlabPublisher extends BaseCommitStatusPublisher {
   private static final Logger LOG = Logger.getInstance(GitlabPublisher.class.getName());
 
   private final WebLinks myLinks;
-  private final RepositoryStateManager myRepositoryStateManager;
 
   public GitlabPublisher(@NotNull WebLinks links,
-                         @NotNull RepositoryStateManager repositoryStateManager,
                          @NotNull Map<String, String> params) {
     super(params);
     myLinks = links;
-    myRepositoryStateManager = repositoryStateManager;
   }
 
 
@@ -94,8 +91,8 @@ public class GitlabPublisher extends BaseCommitStatusPublisher {
     Repository repository = parseRepository(root);
     if (repository == null)
       throw new PublishError("Cannot parse repository from VCS root url " + root.getName());
-    BuildChangesLoaderContext.getVcsBranchName(myRepositoryStateManager, build.getBranch(), build.getBuildType(), root);
-    String message = createMessage(status, build, root, myLinks.getViewResultsUrl(build), description);
+
+    String message = createMessage(status, build, revision, myLinks.getViewResultsUrl(build), description);
     try {
       publish(revision.getRevision(), message, repository);
     } catch (Exception e) {
@@ -131,21 +128,20 @@ public class GitlabPublisher extends BaseCommitStatusPublisher {
   @NotNull
   private String createMessage(@NotNull GitlabBuildStatus status,
                                @NotNull SBuild build,
-                               @NotNull VcsRootInstance root,
+                               @NotNull BuildRevision revision,
                                @NotNull String url,
                                @NotNull String description) {
-    SBuildType buildType = build.getBuildType();
-    String ref = null;
-    if (buildType != null) {
-      ref = BuildChangesLoaderContext.getVcsBranchName(myRepositoryStateManager, build.getBranch(), build.getBuildType(), root);
-      if (ref.startsWith(REFS_HEADS)) {
-        ref = ref.substring(REFS_HEADS.length());
-      } else if (ref.startsWith(REFS_TAGS)) {
-        ref = ref.substring(REFS_TAGS.length());
-      } else {
-        ref = null;
-      }
+
+    RepositoryVersion repositoryVersion = revision.getRepositoryVersion();
+    String ref = repositoryVersion.getVcsBranch();
+    if (ref.startsWith(REFS_HEADS)) {
+      ref = ref.substring(REFS_HEADS.length());
+    } else if (ref.startsWith(REFS_TAGS)) {
+      ref = ref.substring(REFS_TAGS.length());
+    } else {
+      ref = null;
     }
+
     StringBuilder result = new StringBuilder();
     result.append("{").append("\"state\":").append("\"").append(status.getName()).append("\",")
             .append("\"name\":").append("\"").append(build.getBuildTypeName()).append("\",")

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
@@ -76,13 +76,6 @@ public class GitlabPublisher extends BaseCommitStatusPublisher {
   }
 
 
-  @Override
-  public boolean buildFailureDetected(@NotNull SRunningBuild build, @NotNull BuildRevision revision) {
-    publish(build, revision, GitlabBuildStatus.FAILED, build.getStatusDescriptor().getText());
-    return true;
-  }
-
-
   private void publish(@NotNull SBuild build,
                        @NotNull BuildRevision revision,
                        @NotNull GitlabBuildStatus status,

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
@@ -17,12 +17,9 @@ import java.util.Map;
 public class GitlabSettings implements CommitStatusPublisherSettings {
 
   private final WebLinks myLinks;
-  private final RepositoryStateManager myRepositoryStateManager;
 
-  public GitlabSettings(@NotNull WebLinks links,
-                        @NotNull RepositoryStateManager repositoryStateManager) {
+  public GitlabSettings(@NotNull WebLinks links) {
     myLinks = links;
-    myRepositoryStateManager = repositoryStateManager;
   }
 
   @NotNull
@@ -52,7 +49,7 @@ public class GitlabSettings implements CommitStatusPublisherSettings {
   @NotNull
   @Override
   public GitlabPublisher createPublisher(@NotNull Map<String, String> params) {
-    return new GitlabPublisher(myLinks, myRepositoryStateManager, params);
+    return new GitlabPublisher(myLinks, params);
   }
 
   @NotNull


### PR DESCRIPTION
Some Improvements and fixes for the GitLab Implementation.

- Determine ref using RepositoryVersion, this is stable even if during the building (after the checkout) the remote branch has been removed, e.g. through accepting a merge-request in GitLab. Otherwise by using BuildChangesLoaderContext the branch is null and this gets mapped by GitLab to the first branch containing the commit, which would be master after accepting the merge-request. Thus this will result in having an incorrect ref compared to the actual build or even adding a duplicate build and leaving the other one with specified ref in "running" state.

- Do not publish Failed State to GitLab on buildFailureDetected, this sets the build to a final state, meaning the duration gets calculated. Furthermore the second publish in buildFinished leads to creating an new build in GitLab.