### PR TITLE
Improve GitHub support with queued builds reporting and custom contexts.

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/GitHubSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/GitHubSettings.java
@@ -1,17 +1,18 @@
 package jetbrains.buildServer.commitPublisher.github;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import jetbrains.buildServer.commitPublisher.CommitStatusPublisher;
+import jetbrains.buildServer.commitPublisher.CommitStatusPublisherSettings;
 import jetbrains.buildServer.commitPublisher.Constants;
+import jetbrains.buildServer.commitPublisher.github.api.GitHubApiAuthenticationType;
+import jetbrains.buildServer.commitPublisher.github.api.GitHubApiFactory;
+import jetbrains.buildServer.commitPublisher.github.ui.UpdateChangesConstants;
 import jetbrains.buildServer.parameters.ReferencesResolverUtil;
 import jetbrains.buildServer.serverSide.InvalidProperty;
 import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import jetbrains.buildServer.util.StringUtil;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import jetbrains.buildServer.commitPublisher.CommitStatusPublisherSettings;
-import jetbrains.buildServer.commitPublisher.github.api.GitHubApiAuthenticationType;
-import jetbrains.buildServer.commitPublisher.github.api.GitHubApiFactory;
-import jetbrains.buildServer.commitPublisher.github.ui.UpdateChangesConstants;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,6 +47,7 @@ public class GitHubSettings implements CommitStatusPublisherSettings {
     final Map<String, String> result = new HashMap<String, String>();
     final UpdateChangesConstants C = new UpdateChangesConstants();
     result.put(C.getServerKey(), GitHubApiFactory.DEFAULT_URL);
+    result.put(C.getContextKey(), GitHubApiFactory.DEFAULT_CONTEXT);
     return result;
   }
 

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/api/GitHubApiFactory.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/api/GitHubApiFactory.java
@@ -23,7 +23,8 @@ import org.jetbrains.annotations.NotNull;
  * Date: 06.09.12 2:54
  */
 public interface GitHubApiFactory {
-  public static final String DEFAULT_URL = "https://api.github.com";
+  String DEFAULT_URL = "https://api.github.com";
+  String DEFAULT_CONTEXT = "continuous-integration/teamcity";
 
   @NotNull
   GitHubApi openGitHubForUser(@NotNull String url,

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/ui/UpdateChangesConstants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/ui/UpdateChangesConstants.java
@@ -29,6 +29,7 @@ public class UpdateChangesConstants {
   public String getPasswordKey() { return Constants.GITHUB_PASSWORD; }
   public String getAccessTokenKey() { return Constants.GITHUB_TOKEN; }
   public String getAuthenticationTypeKey() { return Constants.GITHUB_AUTH_TYPE;}
+  public String getContextKey() { return Constants.GITHUB_CONTEXT; }
   public String getAuthenticationTypePasswordValue() { return GitHubApiAuthenticationType.PASSWORD_AUTH.getValue();}
   public String getAuthenticationTypeTokenValue() { return GitHubApiAuthenticationType.TOKEN_AUTH.getValue();}
 }

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/github/githubSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/github/githubSettings.jsp
@@ -70,4 +70,14 @@
     </span>
     </td>
   </tr>
+  <tr>
+    <th><label for="${keys.contextKey}">Status Context: <l:star/></label></th>
+    <td>
+      <props:textProperty name="${keys.contextKey}" className="longField"/>
+      <span class="error" id="error_${keys.contextKey}"></span>
+    <span class="smallNote">
+      GitHub status context name. Specifies what service is providing the status updates.
+    </span>
+    </td>
+  </tr>
 </table>


### PR DESCRIPTION
I've added basic reporting for queued builds to this plugin. My team uses TeamCity and GitHub together, and it was frustrating to not immediately see an in-progress status for TeamCity if a build had to be added to the queue and not run immediately.
