### PR TITLE
Explicitly specify the "Verified" label for Gerrit.

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gerrit/GerritPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gerrit/GerritPublisher.java
@@ -59,7 +59,7 @@ public class GerritPublisher extends BaseCommitStatusPublisher {
 
     StringBuilder command = new StringBuilder();
     command.append("gerrit review --project ").append(getGerritProject())
-           .append(" --verified ").append(vote)
+           .append(" --label Verified=").append(vote)
            .append(" -m \"").append(msg).append("\" ")
            .append(revision.getRevision());
     try {


### PR DESCRIPTION
This is more robust than using the `--verified` option to `gerrit review`. The `--verified` shortcut only works if the "Verified" label is defined for the entire Gerrit instance (ie. on the All-Projects root project), as distinct from being defined for some of the individual repositories.

See https://gerrit-documentation.storage.googleapis.com/Documentation/2.12.3/cmd-review.html
