### PR TITLE
Adjust api calls to gitlab documentation 

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
@@ -46,6 +46,8 @@ public class Constants {
 
   public static final String GITLAB_PUBLISHER_ID = "gitlabStatusPublisher";
   public static final String GITLAB_API_URL = "gitlabApiUrl";
+  public static final String GITLAB_GROUP_NAME = "gitlabGroupName";
+  public static final String GITLAB_PROJECT_NAME = "gitlabProjectName";
   public static final String GITLAB_TOKEN = "secure:gitlabAccessToken";
 
 
@@ -143,6 +145,12 @@ public class Constants {
   public String getGitlabServer() {
     return GITLAB_API_URL;
   }
+
+  @NotNull
+  public String getGitlabGroup() { return GITLAB_GROUP_NAME; }
+
+  @NotNull
+  public String getGitlabProject() { return  GITLAB_PROJECT_NAME; }
 
   @NotNull
   public String getGitlabToken() {

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
@@ -1,5 +1,6 @@
 package jetbrains.buildServer.commitPublisher.gitlab;
 
+import com.google.gson.Gson;
 import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.commitPublisher.*;
 import jetbrains.buildServer.serverSide.*;
@@ -7,11 +8,14 @@ import jetbrains.buildServer.vcs.VcsRootInstance;
 import jetbrains.buildServer.web.util.WebUtil;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -98,7 +102,9 @@ public class GitlabPublisher extends BaseCommitStatusPublisher {
     HttpPost post = null;
     HttpResponse response = null;
     try {
-      String url = getApiUrl() + "/projects/" + repository.owner() + "%2F" + repository.repositoryName() + "/statuses/" + commit;
+      String groupAndProject = getGroupAndProject(repository);
+      int projectId = getProjectId(groupAndProject);
+      String url = getApiUrl() + "/projects/" + projectId + "/statuses/" + commit;
       LOG.debug("Request url: " + url + ", message: " + data);
       post = new HttpPost(url);
       post.addHeader("PRIVATE-TOKEN", getPrivateToken());
@@ -115,6 +121,41 @@ public class GitlabPublisher extends BaseCommitStatusPublisher {
     }
   }
 
+  @NotNull
+  private int getProjectId(@NotNull String groupProject) throws Exception  {
+    DefaultHttpClient client = new DefaultHttpClient();
+    HttpGet post = null;
+    HttpResponse response = null;
+    try {
+      String url = getApiUrl() + "/projects/" + groupProject;
+      post = new HttpGet(url);
+      post.addHeader("PRIVATE-TOKEN", getPrivateToken());
+      LOG.debug("Request url: " + url);
+      response = client.execute(post);
+      if (response.getStatusLine().getStatusCode() >= 400)
+        throw new PublishError("Error while getting project id in commit status publisher , response status " + response.getStatusLine());
+      String json = EntityUtils.toString(response.getEntity(), "UTF-8");
+      LOG.debug("Response is: " + json);
+      Gson gson = new com.google.gson.Gson();
+      ProjectIdResponse projectIdResponse = gson.fromJson(json, ProjectIdResponse.class);
+      return projectIdResponse.getId();
+    } finally {
+      HttpClientUtils.closeQuietly(response);
+      releaseConnection(post);
+      HttpClientUtils.closeQuietly(client);
+    }
+  }
+
+  @NotNull
+  private String getGroupAndProject(@NotNull Repository repository) {
+    String projectName = myParams.get(Constants.GITLAB_PROJECT_NAME);
+    String groupName = myParams.get(Constants.GITLAB_GROUP_NAME);
+    if(projectName == null || groupName == null) {
+      return repository.owner() + "%2F" + repository.repositoryName();
+    } else {
+      return groupName + "%2F" + projectName;
+    }
+  }
 
   @NotNull
   private String createMessage(@NotNull GitlabBuildStatus status,
@@ -173,13 +214,22 @@ public class GitlabPublisher extends BaseCommitStatusPublisher {
     return myParams.get(Constants.GITLAB_TOKEN);
   }
 
-  private void releaseConnection(@Nullable HttpPost post) {
+  private <T extends HttpRequestBase> void releaseConnection(@Nullable T post) {
     if (post != null) {
       try {
         post.releaseConnection();
       } catch (Exception e) {
         LOG.warn("Error releasing connection", e);
       }
+    }
+  }
+
+  private class ProjectIdResponse {
+
+    private int id;
+
+    public int getId() {
+      return id;
     }
   }
 

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/gitlab/gitlabSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/gitlab/gitlabSettings.jsp
@@ -8,9 +8,31 @@
         <td>
             <props:textProperty name="${keys.gitlabServer}" style="width:18em;"/>
             <span class="smallNote">
-                Format: <strong>http(s)://[hostname:port]/api/v3</strong>
+                Format: <strong>http(s)://[hostname:port]/api/v3</strong>.
             </span>
             <span class="error" id="error_${keys.gitlabServer}"></span>
+        </td>
+    </tr>
+
+    <tr>
+        <th><label for="${keys.gitlabGroup}">Group: </label></th>
+        <td>
+            <props:textProperty name="${keys.gitlabGroup}" style="width:18em;"/>
+            <span class="smallNote">
+                Format: gitlab-org part in https://gitlab.com/gitlab-org/gitlab-ce.<br /> By default it will be taken from VCS settings.
+            </span>
+            <span class="error" id="error_${keys.gitlabGroup}"></span>
+        </td>
+    </tr>
+
+    <tr>
+        <th><label for="${keys.gitlabProject}">Project: </label></th>
+        <td>
+            <props:textProperty name="${keys.gitlabProject}" style="width:18em;"/>
+            <span class="smallNote">
+                Format: gitlab-ce part in https://gitlab.com/gitlab-org/gitlab-ce.<br /> By default it will be taken from VCS settings.
+            </span>
+            <span class="error" id="error_${keys.gitlabProject}"></span>
         </td>
     </tr>
 
@@ -19,7 +41,7 @@
         <td>
             <props:passwordProperty name="${keys.gitlabToken}" style="width:18em;"/>
             <span class="smallNote">
-                Can be found at <strong>/profile/account</strong> in GitLab
+                Can be found at <strong>/profile/account</strong> in GitLab.
             </span>
             <span class="error" id="error_${keys.gitlabToken}"></span>
         </td>


### PR DESCRIPTION
In gitlab documentation publishing commit status require project id as iteger.
`POST /projects/:id/statuses/:sha`
http://docs.gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit
http://docs.gitlab.com/ce/api/commits.html#post-the-build-status-to-a-commit
However in `master` project id represents as
```java
String url = getApiUrl() + "/projects/" + repository.owner() + "%2F" + repository.repositoryName() + "/statuses/" + commit;
```
For eliminating this difference I created additional call to 
http://docs.gitlab.com/ee/api/projects.html#get-single-project
http://docs.gitlab.com/ce/api/projects.html#get-single-project