### PR TITLE
Interpret refs/open-pull/123/merge as pull request

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/api/impl/GitHubApiImpl.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/api/impl/GitHubApiImpl.java
@@ -54,7 +54,7 @@ import java.util.regex.Pattern;
  */
 public abstract class GitHubApiImpl implements GitHubApi {
   private static final Logger LOG = Logger.getInstance(GitHubApiImpl.class.getName());
-  private static final Pattern PULL_REQUEST_BRANCH = Pattern.compile("/?refs/pull/(\\d+)/(.*)");
+  private static final Pattern PULL_REQUEST_BRANCH = Pattern.compile("/?refs/[^/]*pull/(\\d+)/(.*)");
 
   private final HttpClientWrapper myClient;
   private final GitHubApiPaths myUrls;


### PR DESCRIPTION
Github is not removing the merge branches of closed prs. Those branches are even updated when master advances. This causes closed prs to be built as if they are open. To avoid this, I created a program that uses the github api to find out which prs are open and create branches only for those. These branches are under `refs/open-pull/...` since `refs/pull/...` is read only.

This commit makes the plugin able to find those branches and interpret them as ordinary pull-request branches so that the status can be reported back to github.