### PR TITLE
Improve Bitbucket support to sent back build statuses for pull requests

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
@@ -24,6 +24,8 @@ public class Constants {
 
   public static final String STASH_PUBLISHER_ID = "atlassianStashPublisher";
   public static final String STASH_BASE_URL = "stashBaseUrl";
+  public static final String STASH_PROJECT_KEY = "stashProjectKey";
+  public static final String STASH_REPO_NAME = "stashRepoName";
   public static final String STASH_USERNAME = "stashUsername";
   public static final String STASH_PASSWORD = "secure:stashPassword";
 
@@ -91,9 +93,13 @@ public class Constants {
   }
 
   @NotNull
-  public String getStashBaseUrl() {
-    return STASH_BASE_URL;
-  }
+  public String getStashBaseUrl() { return STASH_BASE_URL; }
+
+  @NotNull
+  public String getStashProjectKey() { return STASH_PROJECT_KEY; }
+
+  @NotNull
+  public String getStashRepoName() { return STASH_REPO_NAME; }
 
   @NotNull
   public String getStashUsername() {

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/data/PullRequestInfo.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/data/PullRequestInfo.java
@@ -1,0 +1,14 @@
+package jetbrains.buildServer.commitPublisher.stash.data;
+
+import java.util.Collection;
+
+/**
+ * Created by rafalkasa on 2017-03-19.
+ */
+
+/**
+ * This class does not represent full repository information
+ */
+public class PullRequestInfo {
+    public Collection<StashCommit> values;
+}

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/data/StashCommit.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/data/StashCommit.java
@@ -1,0 +1,13 @@
+package jetbrains.buildServer.commitPublisher.stash.data;
+
+/**
+ * Created by rafalkasa on 2017-03-19.
+ */
+
+/**
+ * This class does not represent full repository information
+ */
+public class StashCommit {
+    public String id;
+    public String displayId;
+}

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/stash/stashSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/stash/stashSettings.jsp
@@ -21,19 +21,35 @@
       <span class="error" id="error_${keys.stashBaseUrl}"></span>
     </td>
   </tr>
-
-  <tr>
-    <th><label for="${keys.stashUsername}">Username: <l:star/></label></th>
-    <td>
-      <props:textProperty name="${keys.stashUsername}" style="width:18em;"/>
-    </td>
-  </tr>
-
-  <tr>
-    <th><label for="${keys.stashPassword}">Password: <l:star/></label></th>
-    <td>
-      <props:passwordProperty name="${keys.stashPassword}" style="width:18em;"/>
-    </td>
-  </tr>
+  <l:settingsGroup title="Repository">
+    <span class="smallNote">Plugin will recognize Pull Request branches only when <strong><a href="https://confluence.jetbrains.com/display/TCD10/Working+with+Feature+Branches">Branch specification</a></strong> parameter in <strong>VCS Roots</strong> will be configured as below:</span>
+    <span class="smallNote"><strong><i>+:refs/pull-requests/(*/merge)</i></strong></span>
+    <tr>
+      <th><label for="${keys.stashProjectKey}">Project Key: <l:star/></label></th>
+      <td>
+        <props:textProperty name="${keys.stashProjectKey}" style="width:18em;"/>
+      </td>
+    </tr>
+    <tr>
+      <th><label for="${keys.stashRepoName}">Repository: <l:star/></label></th>
+      <td>
+        <props:textProperty name="${keys.stashRepoName}" style="width:18em;"/>
+      </td>
+    </tr>
+  </l:settingsGroup>
+  <l:settingsGroup title="Authentication">
+    <tr>
+      <th><label for="${keys.stashUsername}">Username: <l:star/></label></th>
+      <td>
+        <props:textProperty name="${keys.stashUsername}" style="width:18em;"/>
+      </td>
+    </tr>
+    <tr>
+      <th><label for="${keys.stashPassword}">Password: <l:star/></label></th>
+      <td>
+        <props:passwordProperty name="${keys.stashPassword}" style="width:18em;"/>
+      </td>
+    </tr>
+  </l:settingsGroup>
 </table>
 


### PR DESCRIPTION
Few weeks ago my Team start to using Bitbucket with Pull Request workflow, TeamCity can build our pull request branches but commit status unfortunately was not sent back to the Bitbucket.

I spent some time to investigate how I can find pull request commit number to sent this information correct to the Bitbucket.
Unfortunately Commit Status Publisher plugin sent commit status with last revision number which was Bitbucket automatic merge.

Changes made by me allow you to sent information back to the your  Bitbucket / Stash

<span class="smallNote">Plugin will recognize Pull Request branches only when <strong><a href="https://confluence.jetbrains.com/display/TCD10/Working+with+Feature+Branches">Branch specification</a></strong> parameter in <strong>VCS Roots</strong> will be configured as below:</span>
<span class="smallNote"><strong><i>+:refs/pull-requests/(*/merge)</i></strong></span>

Hadi Hariri also create very good post how to prepare Pull Request build from Github but follow the information you can understand how to configure your Bitbucket project because some of concepts are the same. 
[Automatically Building Pull Requests from GitHub](https://blog.jetbrains.com/teamcity/2013/02/automatically-building-pull-requests-from-github-with-teamcity/)

I share this pull request with others to help resolve others the same issue as my Team had.

Look below how your Pull Request can look in Bitbucket :-)

![image](https://cloud.githubusercontent.com/assets/19885116/24100566/0d62179a-0d75-11e7-9093-58f21dbc2f87.png)

Configuration plugin view in TeamCity:

![image](https://cloud.githubusercontent.com/assets/19885116/24100478/b6d23c20-0d74-11e7-9b1a-8503e02a8913.png)

