### PR TITLE
compatible with gitlab 9.0 subgroups

### DIFF
--- a/commit-status-publisher-server/pom.xml
+++ b/commit-status-publisher-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>commit-status-publisher</artifactId>
     <groupId>org.jetbrains.teamcity</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <properties>
     <teamcity.path.testlib>${project.basedir}/../../../.idea_artifacts/dist_openapi_integration/tests</teamcity.path.testlib>

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/GitRepositoryParser.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/GitRepositoryParser.java
@@ -12,9 +12,9 @@ import java.util.regex.Pattern;
 public class GitRepositoryParser {
   private static final Logger LOG = Logger.getInstance(GitRepositoryParser.class.getName());
   //git@host:user/repo
-  private static final Pattern SCP_PATTERN = Pattern.compile("git@[^:]+[:]([^/]+)/(.+)");
+  private static final Pattern SCP_PATTERN = Pattern.compile("git@[^:]+[:](.+)/(.+)");
   //ssh://git@host/user/repo
-  private static final Pattern SSH_PATTERN = Pattern.compile("ssh://(?:git@)?[^:]+(?::[0-9]+)?[:/]([^/:]+)/(.+)");
+  private static final Pattern SSH_PATTERN = Pattern.compile("ssh://(?:git@)?[^:]+(?::[0-9]+)?[:/]([^:]+)/(.+)");
 
   @Nullable
   public static Repository parseRepository(@NotNull String uri) {

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
@@ -138,14 +138,14 @@ public class GitlabSettings extends BasePublisherSettings implements CommitStatu
   }
 
   /**
-   * GitLab REST API fails to interpret dots in user/group and project names
+   * GitLab REST API fails to interpret dots in (user/group or user/subgroup/) and project names
    * used within project ids in URLs for some calls.
    */
   public static String encodeDots(@NotNull String s) {
     if (!s.contains(".")
         || TeamCityProperties.getBoolean("teamcity.commitStatusPublisher.gitlab.disableUrlEncodingDots"))
       return s;
-    return s.replace(".", "%2E");
+    return s.replace(".", "%2E").replace("/","%2F");
   }
 
   @Override


### PR DESCRIPTION
compatible with gitlab 9.0 subgroups: rootGroup/[subGroup1/subGroup2/]project