### PR TITLE
Add VSTS/TFS support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+charset=utf-8
+end_of_line=crlf
+insert_final_newline=false
+indent_style=space
+indent_size=2

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsConstants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsConstants.java
@@ -1,0 +1,28 @@
+package jetbrains.buildServer.commitPublisher.tfs;
+
+import jetbrains.buildServer.agent.Constants;
+
+public class TfsConstants {
+  public static final String ID = "tfs";
+  public static final String AUTHENTICATION_TYPE = "tfsAuthType";
+  public static final String ACCESS_TOKEN = Constants.SECURE_PROPERTY_PREFIX + "accessToken";
+  public static final String AUTH_USER = "tfsAuthUser";
+  public static final String AUTH_PROVIDER_ID = "tfsAuthProviderId";
+  public static final String GIT_VCS_ROOT = "jetbrains.git";
+
+  public String getAuthenticationTypeKey() {
+    return AUTHENTICATION_TYPE;
+  }
+
+  public String getAccessTokenKey() {
+    return ACCESS_TOKEN;
+  }
+
+  public String getAuthUser() {
+    return AUTH_USER;
+  }
+
+  public String getAuthProviderId() {
+    return AUTH_PROVIDER_ID;
+  }
+}

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsConstants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsConstants.java
@@ -9,6 +9,7 @@ public class TfsConstants {
   public static final String AUTH_USER = "tfsAuthUser";
   public static final String AUTH_PROVIDER_ID = "tfsAuthProviderId";
   public static final String GIT_VCS_ROOT = "jetbrains.git";
+  public static final String TFS_PUBLISHER_ENABLE = "teamcity.tfs.publisher.enable";
 
   public String getAuthenticationTypeKey() {
     return AUTHENTICATION_TYPE;

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherConfig.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherConfig.java
@@ -1,0 +1,45 @@
+package jetbrains.buildServer.commitPublisher.tfs;
+
+import jetbrains.buildServer.commitPublisher.CommitStatusPublisherProblems;
+import jetbrains.buildServer.serverSide.TeamCityProperties;
+import jetbrains.buildServer.serverSide.WebLinks;
+import jetbrains.buildServer.serverSide.auth.SecurityContext;
+import jetbrains.buildServer.serverSide.executors.ExecutorServices;
+import jetbrains.buildServer.serverSide.oauth.OAuthConnectionsManager;
+import jetbrains.buildServer.serverSide.oauth.OAuthTokensStorage;
+import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Controls TFS publisher availability.
+ */
+public class TfsPublisherConfig {
+  @Bean(name = "TfsPublisherSettings")
+  @NotNull
+  @Conditional(TfsPublisherActivation.class)
+  public TfsPublisherSettings getIssueProviderType(@NotNull ExecutorServices executorServices,
+                                                   @NotNull PluginDescriptor descriptor,
+                                                   @NotNull WebLinks links,
+                                                   @NotNull CommitStatusPublisherProblems problems,
+                                                   @NotNull OAuthConnectionsManager oauthConnectionsManager,
+                                                   @NotNull OAuthTokensStorage oauthTokensStorage,
+                                                   @NotNull SecurityContext securityContext) {
+    return new TfsPublisherSettings(executorServices, descriptor, links, problems,
+      oauthConnectionsManager, oauthTokensStorage, securityContext);
+  }
+}
+
+/**
+ * TFS publisher activation condition.
+ */
+class TfsPublisherActivation implements Condition {
+  @Override
+  public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+    return TeamCityProperties.getBoolean(TfsConstants.TFS_PUBLISHER_ENABLE);
+  }
+}

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherConfig.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherConfig.java
@@ -7,6 +7,7 @@ import jetbrains.buildServer.serverSide.auth.SecurityContext;
 import jetbrains.buildServer.serverSide.executors.ExecutorServices;
 import jetbrains.buildServer.serverSide.oauth.OAuthConnectionsManager;
 import jetbrains.buildServer.serverSide.oauth.OAuthTokensStorage;
+import jetbrains.buildServer.vcs.VcsModificationHistory;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Bean;
@@ -28,9 +29,10 @@ public class TfsPublisherConfig {
                                                    @NotNull CommitStatusPublisherProblems problems,
                                                    @NotNull OAuthConnectionsManager oauthConnectionsManager,
                                                    @NotNull OAuthTokensStorage oauthTokensStorage,
-                                                   @NotNull SecurityContext securityContext) {
+                                                   @NotNull SecurityContext securityContext,
+                                                   @NotNull VcsModificationHistory vcsHistory) {
     return new TfsPublisherSettings(executorServices, descriptor, links, problems,
-      oauthConnectionsManager, oauthTokensStorage, securityContext);
+      oauthConnectionsManager, oauthTokensStorage, securityContext, vcsHistory);
   }
 }
 

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherSettings.java
@@ -1,0 +1,157 @@
+package jetbrains.buildServer.commitPublisher.tfs;
+
+import jetbrains.buildServer.commitPublisher.*;
+import jetbrains.buildServer.commitPublisher.CommitStatusPublisher.Event;
+import jetbrains.buildServer.serverSide.*;
+import jetbrains.buildServer.serverSide.auth.SecurityContext;
+import jetbrains.buildServer.serverSide.executors.ExecutorServices;
+import jetbrains.buildServer.serverSide.oauth.OAuthConnectionDescriptor;
+import jetbrains.buildServer.serverSide.oauth.OAuthConnectionsManager;
+import jetbrains.buildServer.serverSide.oauth.OAuthToken;
+import jetbrains.buildServer.serverSide.oauth.OAuthTokensStorage;
+import jetbrains.buildServer.serverSide.oauth.tfs.TfsAuthProvider;
+import jetbrains.buildServer.users.SUser;
+import jetbrains.buildServer.users.User;
+import jetbrains.buildServer.util.StringUtil;
+import jetbrains.buildServer.vcs.VcsRoot;
+import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class TfsPublisherSettings extends BasePublisherSettings implements CommitStatusPublisherSettings {
+
+  private final OAuthConnectionsManager myOauthConnectionsManager;
+  private final OAuthTokensStorage myOAuthTokensStorage;
+  private final SecurityContext mySecurityContext;
+  private static final Set<Event> mySupportedEvents = new HashSet<Event>() {{
+    add(Event.STARTED);
+    add(Event.FINISHED);
+    add(Event.INTERRUPTED);
+    add(Event.MARKED_AS_SUCCESSFUL);
+  }};
+
+  public TfsPublisherSettings(@NotNull ExecutorServices executorServices,
+                              @NotNull PluginDescriptor descriptor,
+                              @NotNull WebLinks links,
+                              @NotNull CommitStatusPublisherProblems problems,
+                              @NotNull OAuthConnectionsManager oauthConnectionsManager,
+                              @NotNull OAuthTokensStorage oauthTokensStorage,
+                              @NotNull SecurityContext securityContext) {
+    super(executorServices, descriptor, links, problems);
+    myOauthConnectionsManager = oauthConnectionsManager;
+    myOAuthTokensStorage = oauthTokensStorage;
+    mySecurityContext = securityContext;
+  }
+
+  @NotNull
+  public String getId() {
+    return TfsConstants.ID;
+  }
+
+  @NotNull
+  public String getName() {
+    return "Visual Studio Team Services";
+  }
+
+  @Nullable
+  public String getEditSettingsUrl() {
+    return "tfs/tfsSettings.jsp";
+  }
+
+  @NotNull
+  @Override
+  public Map<OAuthConnectionDescriptor, Boolean> getOAuthConnections(final SProject project, final SUser user) {
+    final List<OAuthConnectionDescriptor> tfsConnections = myOauthConnectionsManager.getAvailableConnectionsOfType(project, TfsAuthProvider.TYPE);
+    final Map<OAuthConnectionDescriptor, Boolean> connections = new LinkedHashMap<OAuthConnectionDescriptor, Boolean>();
+    for (OAuthConnectionDescriptor c : tfsConnections) {
+      connections.put(c, !myOAuthTokensStorage.getUserTokens(c.getId(), user).isEmpty());
+    }
+    return connections;
+  }
+
+  @Override
+  public boolean isTestConnectionSupported() {
+    return true;
+  }
+
+  @Override
+  public void testConnection(@NotNull BuildTypeIdentity buildTypeOrTemplate, @NotNull VcsRoot root, @NotNull Map<String, String> params) throws PublisherException {
+      TfsStatusPublisher.testConnection(root, params);
+  }
+
+  @Nullable
+  public CommitStatusPublisher createPublisher(@NotNull SBuildType buildType, @NotNull String buildFeatureId, @NotNull Map<String, String> params) {
+    return new TfsStatusPublisher(this, buildType, buildFeatureId, myExecutorServices, myLinks, params, myProblems);
+  }
+
+  @NotNull
+  public String describeParameters(@NotNull Map<String, String> params) {
+    return String.format("Post commit status to %s", getName());
+  }
+
+  @Nullable
+  @Override
+  public Map<String, String> getDefaultParameters() {
+    final Map<String, String> result = new HashMap<String, String>();
+    result.put(TfsConstants.AUTHENTICATION_TYPE, "token");
+    return result;
+  }
+
+  @Nullable
+  public PropertiesProcessor getParametersProcessor() {
+    return new PropertiesProcessor() {
+      private boolean checkNotEmpty(@NotNull final Map<String, String> properties,
+                                    @NotNull final String key,
+                                    @NotNull final String message,
+                                    @NotNull final Collection<InvalidProperty> res) {
+        if (isEmpty(properties, key)) {
+          res.add(new InvalidProperty(key, message));
+          return true;
+        }
+        return false;
+      }
+
+      private boolean isEmpty(@NotNull final Map<String, String> properties,
+                              @NotNull final String key) {
+        return StringUtil.isEmptyOrSpaces(properties.get(key));
+      }
+
+      @NotNull
+      public Collection<InvalidProperty> process(@Nullable final Map<String, String> p) {
+        final Collection<InvalidProperty> result = new ArrayList<InvalidProperty>();
+        if (p == null) return result;
+
+        final String authUsername = p.get(TfsConstants.AUTH_USER);
+        final String authProviderId = p.get(TfsConstants.AUTH_PROVIDER_ID);
+        if (authUsername != null && authProviderId != null) {
+          final User currentUser = mySecurityContext.getAuthorityHolder().getAssociatedUser();
+          if (currentUser != null && currentUser instanceof SUser) {
+            for (OAuthToken token : myOAuthTokensStorage.getUserTokens(authProviderId, (SUser) currentUser)) {
+              if (token.getOauthLogin().equals(authUsername)) {
+                p.put(TfsConstants.ACCESS_TOKEN, token.getAccessToken());
+                p.remove(TfsConstants.AUTH_USER);
+                p.remove(TfsConstants.AUTH_PROVIDER_ID);
+              }
+            }
+          }
+        }
+
+        checkNotEmpty(p, TfsConstants.ACCESS_TOKEN, "Personal Access Token must be specified", result);
+
+        return result;
+      }
+    };
+  }
+
+  @Override
+  public boolean isPublishingForVcsRoot(final VcsRoot vcsRoot) {
+    return TfsConstants.GIT_VCS_ROOT.equals(vcsRoot.getVcsName());
+  }
+
+  @Override
+  protected Set<Event> getSupportedEvents() {
+    return mySupportedEvents;
+  }
+}

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherSettings.java
@@ -20,6 +20,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
+/**
+ * Settings for TFS Git commit status publisher.
+ */
 public class TfsPublisherSettings extends BasePublisherSettings implements CommitStatusPublisherSettings {
 
   private final OAuthConnectionsManager myOauthConnectionsManager;

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
@@ -23,6 +23,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Updates TFS Git commit statuses via REST API.
+ */
 class TfsStatusPublisher extends HttpBasedCommitStatusPublisher {
 
   private static final Logger LOG = Logger.getInstance(TfsStatusPublisher.class.getName());

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
@@ -1,0 +1,221 @@
+package jetbrains.buildServer.commitPublisher.tfs;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Pair;
+import jetbrains.buildServer.commitPublisher.*;
+import jetbrains.buildServer.messages.Status;
+import jetbrains.buildServer.serverSide.*;
+import jetbrains.buildServer.serverSide.executors.ExecutorServices;
+import jetbrains.buildServer.serverSide.impl.LogUtil;
+import jetbrains.buildServer.util.StringUtil;
+import jetbrains.buildServer.vcs.VcsRoot;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.util.EntityUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class TfsStatusPublisher extends HttpBasedCommitStatusPublisher {
+
+  private static final Logger LOG = Logger.getInstance(TfsStatusPublisher.class.getName());
+  private static final String COMMITS_URL_FORMAT = "%s/_apis/git/repositories/%s/commits?api-version=1.0&$top=1";
+  private static final String STATUS_URL_FORMAT = "%s/_apis/git/repositories/%s/commits/%s/statuses?api-version=2.1";
+  private static final Gson myGson = new Gson();
+
+  // Captures following groups: (server url + collection) (/_git/) (git project name)
+  // Example: (http://localhost:81/tfs/collection) (/_git/) (git_project)
+  private static final Pattern TFS_GIT_PROJECT_PATTERN = Pattern.compile("(https?\\:\\/\\/.+)(\\/_git\\/)([^\\.\\/\\?]+)");
+  private final WebLinks myLinks;
+
+  TfsStatusPublisher(@NotNull final CommitStatusPublisherSettings settings,
+                     @NotNull final SBuildType buildType,
+                     @NotNull final String buildFeatureId,
+                     @NotNull final ExecutorServices executorServices,
+                     @NotNull final WebLinks webLinks,
+                     @NotNull final Map<String, String> params,
+                     @NotNull final CommitStatusPublisherProblems problems) {
+    super(settings, buildType, buildFeatureId, executorServices, params, problems);
+    myLinks = webLinks;
+  }
+
+  @NotNull
+  public String toString() {
+    return TfsConstants.ID;
+  }
+
+  @NotNull
+  @Override
+  public String getId() {
+    return TfsConstants.ID;
+  }
+
+  @Override
+  public boolean buildStarted(@NotNull SRunningBuild build, @NotNull BuildRevision revision) throws PublisherException {
+    updateBuildStatus(build, revision, true);
+    return true;
+  }
+
+  @Override
+  public boolean buildFinished(@NotNull SFinishedBuild build, @NotNull BuildRevision revision) throws PublisherException {
+    updateBuildStatus(build, revision, false);
+    return true;
+  }
+
+  @Override
+  public boolean buildInterrupted(@NotNull SFinishedBuild build, @NotNull BuildRevision revision) throws PublisherException {
+    updateBuildStatus(build, revision, false);
+    return true;
+  }
+
+  @Override
+  public boolean buildMarkedAsSuccessful(@NotNull final SBuild build, @NotNull final BuildRevision revision, final boolean buildInProgress) throws PublisherException {
+    updateBuildStatus(build, revision, buildInProgress);
+    return true;
+  }
+
+  public static void testConnection(VcsRoot root, Map<String, String> params) throws PublisherException {
+    if (!TfsConstants.GIT_VCS_ROOT.equals(root.getVcsName())) {
+      throw new PublisherException("Status publisher supports only Git VCS roots");
+    }
+
+    final Pair<String, String> settings = getServerAndProject(root);
+    final String url = String.format(COMMITS_URL_FORMAT, settings.first, settings.second);
+    try {
+      final HttpResponseProcessor processor = new DefaultHttpResponseProcessor() {
+        @Override
+        public void processResponse(HttpResponse response) throws HttpPublisherException, IOException {
+          final int status = response.getStatusLine().getStatusCode();
+          if (status == 401) {
+            throw new HttpPublisherException("Invalid credentials: check access token");
+          } else if (status == 403) {
+            throw new HttpPublisherException("Invalid credentials: check access token scopes");
+          }
+
+          final HttpEntity entity = response.getEntity();
+          if (null == entity) {
+            throw new HttpPublisherException("TFS publisher has received no response");
+          }
+
+          final String json = EntityUtils.toString(entity);
+          if (status != 200) {
+            Error error = null;
+            try {
+              error = myGson.fromJson(json, Error.class);
+            } catch (JsonSyntaxException e) {
+              // Invalid JSON response
+            }
+
+            final String message;
+            if (error != null && error.message != null) {
+              message = error.message + ": HTTP response code " + status;
+            } else {
+              message = "Invalid HTTP response code " + status;
+            }
+
+            throw new HttpPublisherException(message);
+          }
+        }
+      };
+
+      HttpHelper.get(url, StringUtil.EMPTY, params.get(TfsConstants.ACCESS_TOKEN),
+        Collections.singletonMap("Accept", "application/json"), BaseCommitStatusPublisher.DEFAULT_CONNECTION_TIMEOUT, processor);
+    } catch (Exception e) {
+      throw new PublisherException(String.format("TFS publisher has failed to connect to repository %s/_git/%s", settings.first, settings.second), e);
+    }
+  }
+
+  private void updateBuildStatus(@NotNull SBuild build, @NotNull BuildRevision revision, boolean isStarting) throws PublisherException {
+    final VcsRoot root = revision.getRoot();
+    if (!TfsConstants.GIT_VCS_ROOT.equals(root.getVcsName())) {
+      LOG.warn("No revisions were found to update TFS Git commit status. Please check you have Git VCS roots in the build configuration");
+      return;
+    }
+
+    final Pair<String, String> settings = getServerAndProject(root);
+    final String url = String.format(STATUS_URL_FORMAT, settings.first, settings.second, revision.getRevision());
+    final CommitStatus status = getCommitStatus(build, isStarting);
+    final String data = myGson.toJson(status);
+
+    postAsync(url, StringUtil.EMPTY, myParams.get(TfsConstants.ACCESS_TOKEN),
+      data, ContentType.APPLICATION_JSON,
+      Collections.singletonMap("Accept", "application/json"),
+      LogUtil.describe(build));
+  }
+
+  @NotNull
+  private CommitStatus getCommitStatus(final SBuild build, final boolean isStarting) {
+    final CommitStatus status = new CommitStatus();
+
+    final StatusState state = getState(isStarting, build.getBuildStatus());
+    status.state = state;
+    status.description = String.format("The build %s #%s %s %s",
+      build.getFullName(), build.getBuildNumber(),
+      isStarting ? "is" : "has", state.toString().toLowerCase());
+    status.targetURL = myLinks.getViewResultsUrl(build);
+
+    final StatusContext context = new StatusContext();
+    context.name = String.format("%s/%s", build.getBuildTypeExternalId(), build.getBuildId());
+    context.genre = "TeamCity";
+    status.context = context;
+
+    return status;
+  }
+
+  private static StatusState getState(boolean isStarting, Status status) {
+    if (!isStarting) {
+      if (status.isSuccessful()) return StatusState.Succeeded;
+      else if (status == Status.ERROR) return StatusState.Error;
+      else if (status == Status.FAILURE) return StatusState.Failed;
+    }
+
+    return StatusState.Pending;
+  }
+
+  private static Pair<String, String> getServerAndProject(VcsRoot root) throws PublisherException {
+    final String url = root.getProperty("url");
+    if (StringUtil.isEmptyOrSpaces(url)) {
+      throw new PublisherException(String.format("Invalid Git VCS root '%s' settings, missing Server URL property", root.getName()));
+    }
+
+    final Matcher matcher = TFS_GIT_PROJECT_PATTERN.matcher(url);
+    if (!matcher.find()) {
+      throw new PublisherException(String.format("Invalid Git server URL '%s'. Publisher supports only TFS servers", url));
+    }
+
+    final String projectName = matcher.group(3);
+    String serverName = matcher.group(1);
+    if (StringUtil.endsWithIgnoreCase(serverName, "DefaultCollection")) {
+      serverName += "/" + projectName;
+    }
+
+    return Pair.create(serverName, projectName);
+  }
+
+  private static class Error {
+    private String message;
+  }
+
+  private static class CommitStatus {
+    private StatusState state;
+    private String description;
+    private String targetURL;
+    private StatusContext context;
+  }
+
+  private static enum StatusState {
+    Pending, Succeeded, Failed, Error
+  }
+
+  private static class StatusContext {
+    private String name;
+    private String genre;
+  }
+}

--- a/commit-status-publisher-server/src/main/resources/META-INF/build-server-plugin-voter.xml
+++ b/commit-status-publisher-server/src/main/resources/META-INF/build-server-plugin-voter.xml
@@ -27,6 +27,9 @@
   <!-- upsource -->
   <bean class="jetbrains.buildServer.commitPublisher.upsource.UpsourceSettings"/>
 
+  <!-- tfs -->
+  <bean class="jetbrains.buildServer.commitPublisher.tfs.TfsPublisherSettings"/>
+
   <bean class="jetbrains.buildServer.commitPublisher.ServerListener">
     <constructor-arg index="0" ref="configActionsDispatcher"/>
   </bean>

--- a/commit-status-publisher-server/src/main/resources/META-INF/build-server-plugin-voter.xml
+++ b/commit-status-publisher-server/src/main/resources/META-INF/build-server-plugin-voter.xml
@@ -28,7 +28,7 @@
   <bean class="jetbrains.buildServer.commitPublisher.upsource.UpsourceSettings"/>
 
   <!-- tfs -->
-  <bean class="jetbrains.buildServer.commitPublisher.tfs.TfsPublisherSettings"/>
+  <bean class="jetbrains.buildServer.commitPublisher.tfs.TfsPublisherConfig"/>
 
   <bean class="jetbrains.buildServer.commitPublisher.ServerListener">
     <constructor-arg index="0" ref="configActionsDispatcher"/>

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/tfs/tfsSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/tfs/tfsSettings.jsp
@@ -1,0 +1,89 @@
+<%@ page import="jetbrains.buildServer.web.openapi.PlaceId" %>
+<%@ include file="/include-internal.jsp" %>
+<%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
+<%@ taglib prefix="l" tagdir="/WEB-INF/tags/layout" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="util" uri="/WEB-INF/functions/util" %>
+
+<jsp:useBean id="keys" class="jetbrains.buildServer.commitPublisher.tfs.TfsConstants"/>
+<jsp:useBean id="oauthConnections" scope="request" type="java.util.Map"/>
+
+<c:url value="/oauth/tfs/token.html" var="getTokenPage"/>
+<c:set var="cameFromUrl" value="${empty param['cameFromUrl'] ? pageUrl : param['cameFromUrl']}"/>
+<c:set var="getTokenPage" value="${getTokenPage}?cameFromUrl=${util:urlEscape(cameFromUrl)}"/>
+
+<c:set var="oauth_connection_fragment">
+  <c:forEach items="${oauthConnections.keySet()}" var="connection">
+    <c:set var="title">Acquire an access token from <c:out value="${connection.parameters['serverUrl']}"/></c:set>
+    <span class="tfsRepoControl">
+      <i class="icon-magic" style="cursor:pointer;" title="${title}"
+         onclick="BS.TfsAccessTokenPopup.showPopup(this, '${connection.id}')"></i>
+    </span>
+  </c:forEach>
+</c:set>
+
+<tr>
+  <th><label for="${keys.accessTokenKey}">Access Token: <l:star/></label></th>
+  <td>
+    <props:passwordProperty name="${keys.accessTokenKey}" className="mediumField"/>
+    ${oauth_connection_fragment}
+    <props:hiddenProperty name="${keys.authenticationTypeKey}"/>
+    <props:hiddenProperty name="${keys.authUser}"/>
+    <props:hiddenProperty name="${keys.authProviderId}"/>
+    <span class="error" id="error_${keys.accessTokenKey}"></span>
+    <span class="smallNote">
+      Personal Access Token should have <strong><em>Code (status)</em></strong>
+      <a href="https://www.visualstudio.com/en-us/docs/integrate/get-started/auth/oauth#scopes" target="_blank">scope</a>
+    </span>
+  </td>
+</tr>
+
+<c:if test="${testConnectionSupported}">
+  <script>
+    $j(document).ready(function () {
+      PublisherFeature.showTestConnection();
+    });
+  </script>
+</c:if>
+
+<script type="text/javascript">
+
+  BS.TfsAccessTokenPopup = new BS.Popup('tfsGetToken', {
+    url: "${getTokenPage}",
+    method: "get",
+    hideDelay: 0,
+    hideOnMouseOut: false,
+    hideOnMouseClickOutside: true
+  });
+
+  BS.TfsAccessTokenPopup.showPopup = function (nearestElement, connectionId) {
+    this.options.parameters = "projectId=${project.externalId}&connectionId=" + connectionId + "&showMode=popup";
+    var that = this;
+
+    window.TfsTokenContentUpdater = function () {
+      that.hidePopup(0);
+      that.showPopupNearElement(nearestElement);
+    };
+    this.showPopupNearElement(nearestElement);
+  };
+
+  window.getOAuthTokenCallback = function (cre) {
+    if (cre != null) {
+      $('${keys.authUser}').value = cre.oauthLogin;
+      $('${keys.authProviderId}').value = cre.oauthProviderId;
+      $('${keys.accessTokenKey}').value = '******************************'
+    }
+    BS.TfsAccessTokenPopup.hidePopup(0, true);
+  };
+</script>
+
+<style type="text/css">
+  .tc-icon_tfs {
+    cursor: pointer;
+  }
+
+  a > .tc-icon_tfs_disabled {
+    text-decoration: none;
+  }
+</style>
+

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/tfs/tfsSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/tfs/tfsSettings.jsp
@@ -32,8 +32,9 @@
     <props:hiddenProperty name="${keys.authProviderId}"/>
     <span class="error" id="error_${keys.accessTokenKey}"></span>
     <span class="smallNote">
-      Personal Access Token should have <strong><em>Code (status)</em></strong>
+      You need to grant <strong><em>Code (status)</em></strong>
       <a href="https://www.visualstudio.com/en-us/docs/integrate/get-started/auth/oauth#scopes" target="_blank">scope</a>
+      for token.
     </span>
   </td>
 </tr>

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherTest.java
@@ -2,13 +2,20 @@ package jetbrains.buildServer.commitPublisher.tfs;
 
 import jetbrains.buildServer.commitPublisher.HttpPublisherTest;
 import jetbrains.buildServer.commitPublisher.MockPluginDescriptor;
+import jetbrains.buildServer.commitPublisher.PublisherException;
+import jetbrains.buildServer.messages.Status;
+import jetbrains.buildServer.serverSide.BuildRevision;
+import jetbrains.buildServer.vcs.VcsRootInstance;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.StringEntity;
 import org.testng.annotations.BeforeMethod;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.assertj.core.api.BDDAssertions.then;
 
 /**
  * @author Dmitry.Tretyakov
@@ -19,19 +26,19 @@ public class TfsPublisherTest extends HttpPublisherTest {
 
   TfsPublisherTest() {
     myExpectedRegExps.put(EventToTest.QUEUED, null); // not to be tested
-    myExpectedRegExps.put(EventToTest.REMOVED, null); // not to be tested
-    myExpectedRegExps.put(EventToTest.STARTED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Build started.*in_progress.*%s.*", REVISION));
-    myExpectedRegExps.put(EventToTest.FINISHED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Success.*success.*%s.*", REVISION));
-    myExpectedRegExps.put(EventToTest.FAILED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Failure.*failed.*%s.*", REVISION));
+    myExpectedRegExps.put(EventToTest.REMOVED, null);  // not to be tested
+    myExpectedRegExps.put(EventToTest.STARTED, String.format("POST /_apis/git/repositories/project/commits/%s/statuses.*ENTITY:.*Pending.*is pending.*", REVISION));
+    myExpectedRegExps.put(EventToTest.FINISHED, String.format("POST /_apis/git/repositories/project/commits/%s/statuses.*ENTITY:.*Succeeded.*has succeeded.*", REVISION));
+    myExpectedRegExps.put(EventToTest.FAILED, String.format("POST /_apis/git/repositories/project/commits/%s/statuses.*ENTITY:.*Failed.*has failed.*", REVISION));
     myExpectedRegExps.put(EventToTest.COMMENTED_SUCCESS, null); // not to be tested
     myExpectedRegExps.put(EventToTest.COMMENTED_FAILED, null); // not to be tested
     myExpectedRegExps.put(EventToTest.COMMENTED_INPROGRESS, null); // not to be tested
     myExpectedRegExps.put(EventToTest.COMMENTED_INPROGRESS_FAILED, null); // not to be tested
-    myExpectedRegExps.put(EventToTest.INTERRUPTED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*%s.*failed.*%s.*", PROBLEM_DESCR, REVISION));
-    myExpectedRegExps.put(EventToTest.FAILURE_DETECTED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*%s.*failed.*%s.*", PROBLEM_DESCR, REVISION));
-    myExpectedRegExps.put(EventToTest.MARKED_SUCCESSFUL, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Build marked as successful.*success.*%s.*", REVISION));
-    myExpectedRegExps.put(EventToTest.MARKED_RUNNING_SUCCESSFUL, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Build marked as successful.*in_progress.*%s.*", REVISION));
-    myExpectedRegExps.put(EventToTest.TEST_CONNECTION, String.format(".*~buildStatusTestConnection.*\"project\":\"PRJ1\".*"));
+    myExpectedRegExps.put(EventToTest.INTERRUPTED, String.format("POST /_apis/git/repositories/project/commits/%s/statuses.*ENTITY:.*Failed.*has failed.*", REVISION));
+    myExpectedRegExps.put(EventToTest.FAILURE_DETECTED, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.MARKED_SUCCESSFUL, String.format("POST /_apis/git/repositories/project/commits/%s/statuses.*ENTITY:.*Succeeded.*has succeeded.*", REVISION)); // not to be tested
+    myExpectedRegExps.put(EventToTest.MARKED_RUNNING_SUCCESSFUL, String.format("POST /_apis/git/repositories/project/commits/%s/statuses.*ENTITY:.*Pending.*is pending.*", REVISION)); // not to be tested
+    myExpectedRegExps.put(EventToTest.TEST_CONNECTION, "GET /_apis/git/repositories/project/commits.*\\$top=1.*"); // not to be tested
   }
 
   @BeforeMethod
@@ -42,6 +49,23 @@ public class TfsPublisherTest extends HttpPublisherTest {
       myOAuthConnectionsManager, myOAuthTokenStorage, myFixture.getSecurityContext());
     Map<String, String> params = getPublisherParams();
     myPublisher = new TfsStatusPublisher(myPublisherSettings, myBuildType, FEATURE_ID, myExecServices, myWebLinks, params, myProblems);
+    myVcsURL = getServerUrl() + "/_git/" + CORRECT_REPO;
+    myReadOnlyVcsURL = getServerUrl()  + "/_git/" + READ_ONLY_REPO;
+    myVcsRoot.setProperties(Collections.singletonMap("url", myVcsURL));
+    VcsRootInstance vcsRootInstance = myBuildType.getVcsRootInstanceForParent(myVcsRoot);
+    myRevision = new BuildRevision(vcsRootInstance, REVISION, "", REVISION);
+  }
+
+  public void should_fail_with_error_on_wrong_vcs_url() throws InterruptedException {
+    myVcsRoot.setProperties(Collections.singletonMap("url", "wrong://url.com"));
+    VcsRootInstance vcsRootInstance = myBuildType.getVcsRootInstanceForParent(myVcsRoot);
+    BuildRevision revision = new BuildRevision(vcsRootInstance, REVISION, "", REVISION);
+    try {
+      myPublisher.buildFinished(myFixture.createBuild(myBuildType, Status.NORMAL), revision);
+      fail("PublishError exception expected");
+    } catch(PublisherException ex) {
+      then(ex.getMessage()).matches("Invalid Git server URL.*" + myVcsRoot.getProperty("url") + ".*");
+    }
   }
 
   @Override
@@ -55,10 +79,9 @@ public class TfsPublisherTest extends HttpPublisherTest {
   protected void populateResponse(HttpRequest httpRequest, String requestData, HttpResponse httpResponse) {
     super.populateResponse(httpRequest, requestData, httpResponse);
     if (httpRequest.getRequestLine().getMethod().equals("GET")) {
-      if (httpRequest.getRequestLine().getUri().endsWith(OWNER + "/repos/" + CORRECT_REPO)) {
-        httpResponse.setEntity(new StringEntity("", "UTF-8"));
-      } else if (httpRequest.getRequestLine().getUri().endsWith(OWNER + "/repos/" + READ_ONLY_REPO)) {
-        httpResponse.setEntity(new StringEntity("", "UTF-8"));
+      if (httpRequest.getRequestLine().getUri().contains(READ_ONLY_REPO)) {
+        httpResponse.setStatusCode(403);
+        httpResponse.setEntity(new StringEntity("{'message': 'error'}", "UTF-8"));
       }
     }
   }

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherTest.java
@@ -1,0 +1,65 @@
+package jetbrains.buildServer.commitPublisher.tfs;
+
+import jetbrains.buildServer.commitPublisher.HttpPublisherTest;
+import jetbrains.buildServer.commitPublisher.MockPluginDescriptor;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.StringEntity;
+import org.testng.annotations.BeforeMethod;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Dmitry.Tretyakov
+ *         Date: 20.04.2017
+ *         Time: 18:06
+ */
+public class TfsPublisherTest extends HttpPublisherTest {
+
+  TfsPublisherTest() {
+    myExpectedRegExps.put(EventToTest.QUEUED, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.REMOVED, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.STARTED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Build started.*in_progress.*%s.*", REVISION));
+    myExpectedRegExps.put(EventToTest.FINISHED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Success.*success.*%s.*", REVISION));
+    myExpectedRegExps.put(EventToTest.FAILED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Failure.*failed.*%s.*", REVISION));
+    myExpectedRegExps.put(EventToTest.COMMENTED_SUCCESS, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.COMMENTED_FAILED, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.COMMENTED_INPROGRESS, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.COMMENTED_INPROGRESS_FAILED, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.INTERRUPTED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*%s.*failed.*%s.*", PROBLEM_DESCR, REVISION));
+    myExpectedRegExps.put(EventToTest.FAILURE_DETECTED, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*%s.*failed.*%s.*", PROBLEM_DESCR, REVISION));
+    myExpectedRegExps.put(EventToTest.MARKED_SUCCESSFUL, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Build marked as successful.*success.*%s.*", REVISION));
+    myExpectedRegExps.put(EventToTest.MARKED_RUNNING_SUCCESSFUL, String.format(".*~buildStatus.*ENTITY:.*PRJ1.*Build marked as successful.*in_progress.*%s.*", REVISION));
+    myExpectedRegExps.put(EventToTest.TEST_CONNECTION, String.format(".*~buildStatusTestConnection.*\"project\":\"PRJ1\".*"));
+  }
+
+  @BeforeMethod
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    myPublisherSettings = new TfsPublisherSettings(myExecServices, new MockPluginDescriptor(), myWebLinks, myProblems,
+      myOAuthConnectionsManager, myOAuthTokenStorage, myFixture.getSecurityContext());
+    Map<String, String> params = getPublisherParams();
+    myPublisher = new TfsStatusPublisher(myPublisherSettings, myBuildType, FEATURE_ID, myExecServices, myWebLinks, params, myProblems);
+  }
+
+  @Override
+  protected Map<String, String> getPublisherParams() {
+    return new HashMap<String, String>() {{
+      put(TfsConstants.ACCESS_TOKEN, "token");
+    }};
+  }
+
+  @Override
+  protected void populateResponse(HttpRequest httpRequest, String requestData, HttpResponse httpResponse) {
+    super.populateResponse(httpRequest, requestData, httpResponse);
+    if (httpRequest.getRequestLine().getMethod().equals("GET")) {
+      if (httpRequest.getRequestLine().getUri().endsWith(OWNER + "/repos/" + CORRECT_REPO)) {
+        httpResponse.setEntity(new StringEntity("", "UTF-8"));
+      } else if (httpRequest.getRequestLine().getUri().endsWith(OWNER + "/repos/" + READ_ONLY_REPO)) {
+        httpResponse.setEntity(new StringEntity("", "UTF-8"));
+      }
+    }
+  }
+}

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/tfs/TfsPublisherTest.java
@@ -46,7 +46,7 @@ public class TfsPublisherTest extends HttpPublisherTest {
   protected void setUp() throws Exception {
     super.setUp();
     myPublisherSettings = new TfsPublisherSettings(myExecServices, new MockPluginDescriptor(), myWebLinks, myProblems,
-      myOAuthConnectionsManager, myOAuthTokenStorage, myFixture.getSecurityContext());
+      myOAuthConnectionsManager, myOAuthTokenStorage, myFixture.getSecurityContext(), myFixture.getVcsHistory());
     Map<String, String> params = getPublisherParams();
     myPublisher = new TfsStatusPublisher(myPublisherSettings, myBuildType, FEATURE_ID, myExecServices, myWebLinks, params, myProblems);
     myVcsURL = getServerUrl() + "/_git/" + CORRECT_REPO;


### PR DESCRIPTION
This change brings VSTS/TFS commit status pulisher support for Git repositories hosted in TFS server.
It uses TFS REST APIs to check repository access and for status publishing. Status publisher supports authentication via Personal Access Tokens and provides helper icons to fill in token from project connections.