### PR TITLE
TW-50105 Use JVM proxy server settings when publishing commit status over http/https

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/HttpHelper.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/HttpHelper.java
@@ -148,7 +148,7 @@ public class HttpHelper {
       credentials.setCredentials(new AuthScope(uri.getHost(), uri.getPort()), new UsernamePasswordCredentials(username, password));
       builder.setDefaultCredentialsProvider(credentials);
     }
-    return builder.build();
+    return builder.useSystemProperties().build();
   }
 
   @NotNull


### PR DESCRIPTION
TW-50105 Commit Status Publisher does not use JVM proxy settings
https://youtrack.jetbrains.com/issue/TW-50105

REPRO STEPS
1) Ensure the TeamCity server does not have direct access to gitlab.com and must go through a proxy.
2) Use the TEAMCITY_SERVER_OPTS environmental variable to configure the JVM proxy settings per the TC documentation
3) Using a build config with a gitlab.com VCS root, add the commit status publisher build feature
4) Run the build.

EXPECTED
The commit status publisher uses the proxy server set in the JVM settings (e.g. https.proxyHost, https.proxyPort, etc) to send the commit status to gitlab.com.

ACTUAL
The commit status publisher fails with a connection timeout.

NOTES
The HttpClient Docs say "System properties will be taken into account when configuring the default implementations when useSystemProperties() method is called prior to calling build()."

Looking at the source code, we are not calling .useSystemProperties() on the HttpConnectionBuilder before we call .build().