### PR TITLE
Adding token authentication to Bitbucket server (Stash).

### DIFF
--- a/CommitStatusPublisher.xml
+++ b/CommitStatusPublisher.xml
@@ -55,7 +55,7 @@
                     <description>
                       Authentication using personal token
                     </description>
-                    <param name="stashToken" dslName="token">
+                    <param name="secure:stashToken" dslName="token">
                       <description>
                         Personal token to use
                       </description>

--- a/CommitStatusPublisher.xml
+++ b/CommitStatusPublisher.xml
@@ -47,15 +47,35 @@
                         Bitbucket Server URL
                     </description>
                 </param>
-                <param name="stashUsername" dslName="userName" mandatory="true">
+                <param name="stashAuthenticationType" dslName="authType" type="compound">
+                  <description>
+                    Type of authentication
+                  </description>
+                  <option name="personalToken" value="token">
                     <description>
+                      Authentication using personal token
+                    </description>
+                    <param name="stashToken" dslName="token">
+                      <description>
+                        Personal token to use
+                      </description>
+                    </param>
+                  </option>
+                  <option name="password" value="password">
+                    <description>
+                      Password authentication
+                    </description>
+                    <param name="stashUsername" dslName="userName">
+                      <description>
                         A username for Bitbucket Server connection
-                    </description>
-                </param>
-                <param name="secure:stashPassword" dslName="password" mandatory="true">
-                    <description>
+                      </description>
+                    </param>
+                    <param name="secure:stashPassword" dslName="password">
+                      <description>
                         A password for Bitbucket Server connection
-                    </description>
+                      </description>
+                    </param>
+                  </option>
                 </param>
             </option>
             <option name="gerrit" value="gerritStatusPublisher">

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
@@ -24,6 +24,8 @@ public class Constants {
 
   public static final String STASH_PUBLISHER_ID = "atlassianStashPublisher";
   public static final String STASH_BASE_URL = "stashBaseUrl";
+  public static final String STASH_AUTH_TYPE = "stashAuthType";
+  public static final String STASH_TOKEN = "stashToken";
   public static final String STASH_USERNAME = "stashUsername";
   public static final String STASH_PASSWORD = "secure:stashPassword";
 
@@ -88,21 +90,6 @@ public class Constants {
   @NotNull
   public String getSshKey() {
     return ServerSshKeyManager.TEAMCITY_SSH_KEY_PROP;
-  }
-
-  @NotNull
-  public String getStashBaseUrl() {
-    return STASH_BASE_URL;
-  }
-
-  @NotNull
-  public String getStashUsername() {
-    return STASH_USERNAME;
-  }
-
-  @NotNull
-  public String getStashPassword() {
-    return STASH_PASSWORD;
   }
 
   @NotNull

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
   public static final String STASH_PUBLISHER_ID = "atlassianStashPublisher";
   public static final String STASH_BASE_URL = "stashBaseUrl";
   public static final String STASH_AUTH_TYPE = "stashAuthType";
-  public static final String STASH_TOKEN = "stashToken";
+  public static final String STASH_TOKEN = "secure:stashToken";
   public static final String STASH_USERNAME = "stashUsername";
   public static final String STASH_PASSWORD = "secure:stashPassword";
 

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashAuthenticationType.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashAuthenticationType.java
@@ -1,0 +1,35 @@
+package jetbrains.buildServer.commitPublisher.stash;
+
+import jetbrains.buildServer.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public enum StashAuthenticationType {
+  TOKEN_AUTH("token"),
+  PASSWORD_AUTH("password"),
+  ;
+
+  private final String myValue;
+
+
+  StashAuthenticationType(@NotNull final String value) {
+    myValue = value;
+  }
+
+  @NotNull
+  public String getValue() {
+    return myValue;
+  }
+
+  @NotNull
+  public static StashAuthenticationType parse(@Nullable final String value) {
+    //migration
+    if (value == null || StringUtil.isEmptyOrSpaces(value)) return PASSWORD_AUTH;
+
+    for (StashAuthenticationType v : values()) {
+      if (v.getValue().equals(value)) return v;
+    }
+
+    throw new IllegalArgumentException("Failed to parse StashAuthenticationType: " + value);
+  }
+}

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashPublisher.java
@@ -19,11 +19,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.google.common.base.Joiner.on;
 import static com.google.common.collect.ImmutableMap.of;
-import static java.lang.String.format;
 
 class StashPublisher extends HttpBasedCommitStatusPublisher {
-  private static final String PUBLISH_QUEUED_BUILD_STATUS = "teamcity.stashCommitStatusPublisher.publishQueuedBuildStatus";
+  public static final String PUBLISH_QUEUED_BUILD_STATUS = "teamcity.stashCommitStatusPublisher.publishQueuedBuildStatus";
 
   private static final Logger LOG = Logger.getInstance(StashPublisher.class.getName());
   private final Gson myGson = new Gson();
@@ -153,7 +153,8 @@ class StashPublisher extends HttpBasedCommitStatusPublisher {
 
   private void vote(@NotNull String commit, @NotNull String data, @NotNull String buildDescription) {
     String url = getBaseUrl() + "/rest/build-status/1.0/commits/" + commit;
-    postAsync(url, getUsername(), getPassword(), data, ContentType.APPLICATION_JSON, of("Authorization", format("Bearer ", getToken())), buildDescription);
+    postAsync(url, getUsername(), getPassword(), data, ContentType.APPLICATION_JSON,
+      of("Authorization", on(' ').join("Bearer", getToken())), buildDescription);
   }
 
   @Override

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashPublisher.java
@@ -19,8 +19,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.google.common.collect.ImmutableMap.of;
+import static java.lang.String.format;
+
 class StashPublisher extends HttpBasedCommitStatusPublisher {
-  public static final String PUBLISH_QUEUED_BUILD_STATUS = "teamcity.stashCommitStatusPublisher.publishQueuedBuildStatus";
+  private static final String PUBLISH_QUEUED_BUILD_STATUS = "teamcity.stashCommitStatusPublisher.publishQueuedBuildStatus";
 
   private static final Logger LOG = Logger.getInstance(StashPublisher.class.getName());
   private final Gson myGson = new Gson();
@@ -150,7 +153,7 @@ class StashPublisher extends HttpBasedCommitStatusPublisher {
 
   private void vote(@NotNull String commit, @NotNull String data, @NotNull String buildDescription) {
     String url = getBaseUrl() + "/rest/build-status/1.0/commits/" + commit;
-    postAsync(url, getUsername(), getPassword(), data, ContentType.APPLICATION_JSON, null, buildDescription);
+    postAsync(url, getUsername(), getPassword(), data, ContentType.APPLICATION_JSON, of("Authorization", format("Bearer ", getToken())), buildDescription);
   }
 
   @Override
@@ -204,6 +207,10 @@ class StashPublisher extends HttpBasedCommitStatusPublisher {
 
   private String getBaseUrl() {
     return HttpHelper.stripTrailingSlash(myParams.get(Constants.STASH_BASE_URL));
+  }
+
+  private String getToken() {
+    return myParams.get(Constants.STASH_TOKEN);
   }
 
   private String getUsername() {

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashSettings.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Joiner.on;
 import static com.google.common.collect.ImmutableMap.of;
 import static java.lang.String.format;
 import static jetbrains.buildServer.commitPublisher.stash.StashPublisher.PUBLISH_QUEUED_BUILD_STATUS;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 
 public class StashSettings extends BasePublisherSettings implements CommitStatusPublisherSettings {
 
@@ -140,12 +141,12 @@ public class StashSettings extends BasePublisherSettings implements CommitStatus
 
       switch (StashAuthenticationType.parse(params.get(C.getAuthenticationTypeKey()))) {
         case PASSWORD_AUTH:
-          HttpHelper.get(url, params.get(C.getStashUsername()), params.get(C.getStashPassword()), of("Accept", "application/json"),
+          HttpHelper.get(url, params.get(C.getStashUsername()), params.get(C.getStashPassword()), of("Accept", APPLICATION_JSON.getMimeType()),
             BaseCommitStatusPublisher.DEFAULT_CONNECTION_TIMEOUT, processor);
           break;
 
         case TOKEN_AUTH:
-          HttpHelper.get(url, "", "", of("Accept", "application/json", "Authorization", on(' ').join("Bearer", params.get(C.getStashToken()))),
+          HttpHelper.get(url, "", "", of("Accept", APPLICATION_JSON.getMimeType(), "Authorization", on(' ').join("Bearer", params.get(C.getStashToken()))),
             BaseCommitStatusPublisher.DEFAULT_CONNECTION_TIMEOUT, processor);
           break;
 

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/ui/UpdateChangesConstants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/ui/UpdateChangesConstants.java
@@ -1,0 +1,14 @@
+package jetbrains.buildServer.commitPublisher.stash.ui;
+
+import jetbrains.buildServer.commitPublisher.Constants;
+import jetbrains.buildServer.commitPublisher.stash.StashAuthenticationType;
+
+public class UpdateChangesConstants {
+  public String getStashBaseUrl() { return Constants.STASH_BASE_URL; }
+  public String getStashUsername() { return Constants.STASH_USERNAME; }
+  public String getStashPassword() { return Constants.STASH_PASSWORD; }
+  public String getStashToken() { return Constants.STASH_TOKEN; }
+  public String getAuthenticationTypeKey() { return Constants.STASH_AUTH_TYPE;}
+  public String getAuthenticationTypePasswordValue() { return StashAuthenticationType.PASSWORD_AUTH.getValue();}
+  public String getAuthenticationTypeTokenValue() { return StashAuthenticationType.TOKEN_AUTH.getValue();}
+}

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/stash/stashSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/stash/stashSettings.jsp
@@ -4,7 +4,8 @@
 <%@ taglib prefix="forms" tagdir="/WEB-INF/tags/forms" %>
 <%@ taglib prefix="bs" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="util" uri="/WEB-INF/functions/util" %>
-<jsp:useBean id="keys" class="jetbrains.buildServer.commitPublisher.Constants"/>
+<jsp:useBean id="keys" class="jetbrains.buildServer.commitPublisher.stash.ui.UpdateChangesConstants"/>
+
   <tr>
     <th><label for="${keys.stashBaseUrl}">Bitbucket Server Base URL: <l:star/></label></th>
     <td>
@@ -14,24 +15,41 @@
     </td>
   </tr>
 
-  <tr>
-    <th><label for="${keys.stashUsername}">Username: <l:star/></label></th>
-    <td>
-      <props:textProperty name="${keys.stashUsername}" className="mediumField"/>
-    </td>
-  </tr>
+  <props:selectSectionProperty name="${keys.authenticationTypeKey}" title="Authentication Type">
 
-  <tr>
-    <th><label for="${keys.stashPassword}">Password: <l:star/></label></th>
-    <td>
-      <props:passwordProperty name="${keys.stashPassword}" className="mediumField"/>
-      <c:if test="${testConnectionSupported}">
-        <script>
-          $j(document).ready(function() {
-            PublisherFeature.showTestConnection("This ensures that the repository is reachable under the provided credentials.\nIf status publishing still fails, it can be due to insufficient permissions of the corresponding BitBucket Server user.");
-          });
-        </script>
-      </c:if>
-    </td>
-  </tr>
+    <props:selectSectionPropertyContent value="${keys.authenticationTypeTokenValue}" caption="Access Token">
+      <tr>
+        <th><label for="${keys.stashToken}">Token: <l:star/></label></th>
+        <td>
+          <props:textProperty name="${keys.stashToken}" className="mediumField"/>
+        </td>
+      </tr>
+    </props:selectSectionPropertyContent>
+
+    <props:selectSectionPropertyContent value="${keys.authenticationTypePasswordValue}" caption="Password">
+      <tr>
+        <th><label for="${keys.stashUsername}">Username: <l:star/></label></th>
+        <td>
+          <props:textProperty name="${keys.stashUsername}" className="mediumField"/>
+        </td>
+      </tr>
+
+      <tr>
+        <th><label for="${keys.stashPassword}">Password: <l:star/></label></th>
+        <td>
+          <props:passwordProperty name="${keys.stashPassword}" className="mediumField"/>
+        </td>
+      </tr>
+    </props:selectSectionPropertyContent>
+
+  </props:selectSectionProperty>
+
+  <c:if test="${testConnectionSupported}">
+    <script>
+      $j(document).ready(function() {
+        PublisherFeature.showTestConnection("This ensures that the repository is reachable under the provided credentials.\nIf status publishing still fails, it can be due to insufficient permissions of the corresponding BitBucket Server user.");
+      });
+    </script>
+  </c:if>
+
 

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/stash/stashSettings.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/stash/stashSettings.jsp
@@ -21,7 +21,7 @@
       <tr>
         <th><label for="${keys.stashToken}">Token: <l:star/></label></th>
         <td>
-          <props:textProperty name="${keys.stashToken}" className="mediumField"/>
+          <props:passwordProperty name="${keys.stashToken}" className="mediumField"/>
         </td>
       </tr>
     </props:selectSectionPropertyContent>

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/StashPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/StashPublisherTest.java
@@ -82,6 +82,7 @@ public class StashPublisherTest extends HttpPublisherTest {
   @Override
   protected Map<String, String> getPublisherParams() {
     return new HashMap<String, String>() {{
+      put(Constants.STASH_TOKEN, "token");
       put(Constants.STASH_USERNAME, "user");
       put(Constants.STASH_PASSWORD, "pwd");
       put(Constants.STASH_BASE_URL, getServerUrl());


### PR DESCRIPTION
BitBucket 5.5 introduced personal user tokens authentication: https://confluence.atlassian.com/bitbucketserver/bitbucket-server-5-5-release-notes-938037662.html

I made changed to the Stash configuration similar to GitHub (dropdown with auth type selection). Preview: https://www.dropbox.com/s/8vbppp0rvx1jxrr/Screenshot%202017-10-27%2017.02.12.png?dl=0