### PR TITLE
Add posibility to publish build status to all dependencies

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListener.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListener.java
@@ -1,13 +1,17 @@
 package jetbrains.buildServer.commitPublisher;
 
 import com.intellij.openapi.diagnostic.Logger;
+
 import java.util.*;
+
 import jetbrains.buildServer.BuildProblemData;
 import jetbrains.buildServer.messages.Status;
 import jetbrains.buildServer.serverSide.*;
+import jetbrains.buildServer.serverSide.dependency.Dependency;
 import jetbrains.buildServer.serverSide.impl.LogUtil;
 import jetbrains.buildServer.users.User;
 import jetbrains.buildServer.util.EventDispatcher;
+import jetbrains.buildServer.util.StringUtil;
 import jetbrains.buildServer.vcs.SVcsModification;
 import jetbrains.buildServer.vcs.SVcsRoot;
 import org.jetbrains.annotations.NotNull;
@@ -18,6 +22,7 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
 
   private final static Logger LOG = Logger.getInstance(CommitStatusPublisherListener.class.getName());
   private final static String PUBLISHING_ENABLED_PROPERTY_NAME = "teamcity.commitStatusPublisher.enabled";
+  private final static String PUBLISHING_TO_DEPENDENCIES_ENABLED_PROPERTY_NAME = "teamcity.commitStatusPublisher.publishToDependencies";
 
   private final PublisherManager myPublisherManager;
   private final BuildHistory myBuildHistory;
@@ -129,7 +134,7 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
       return;
 
     if (!before.isEmpty() && after.isEmpty()) {
-      runForEveryPublisher(Event.MARKED_AS_SUCCESSFUL, buildType, build, new PublishTask()  {
+      runForEveryPublisher(Event.MARKED_AS_SUCCESSFUL, buildType, build, new PublishTask() {
         @Override
         public boolean run(@NotNull CommitStatusPublisher publisher, @NotNull BuildRevision revision) throws PublisherException {
           return publisher.buildMarkedAsSuccessful(build, revision, isBuildInProgress(build));
@@ -172,8 +177,13 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
   private boolean isPublishingDisabled(SBuildType buildType) {
     String publishingEnabledParam = buildType.getParameterValue(PUBLISHING_ENABLED_PROPERTY_NAME);
     return "false".equals(publishingEnabledParam)
-           || !(TeamCityProperties.getBooleanOrTrue(PUBLISHING_ENABLED_PROPERTY_NAME)
-                || "true".equals(publishingEnabledParam));
+      || !(TeamCityProperties.getBooleanOrTrue(PUBLISHING_ENABLED_PROPERTY_NAME)
+      || "true".equals(publishingEnabledParam));
+  }
+
+  private boolean isPublishingToDependenciesEnabled(SBuildType buildType) {
+    String publishingEnabledParam = buildType.getParameterValue(PUBLISHING_TO_DEPENDENCIES_ENABLED_PROPERTY_NAME);
+    return StringUtil.areEqualIgnoringCase("true", publishingEnabledParam);
   }
 
   private void logStatusNotPublished(@NotNull Event event, @NotNull String buildDescription, @NotNull CommitStatusPublisher publisher, @NotNull String message) {
@@ -181,38 +191,71 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
   }
 
   private void runForEveryPublisher(@NotNull Event event, @NotNull SBuildType buildType, @NotNull SBuild build, @NotNull PublishTask task) {
+    final String description = LogUtil.describe(build);
+    Set<BuildRevision> publishedRevisions = new HashSet<BuildRevision>();
+    runForEveryPublisher(event, buildType, build, task, description, publishedRevisions);
+
+    if (!isPublishingToDependenciesEnabled(buildType)) {
+      return;
+    }
+
+    for (BuildPromotion bp : build.getBuildPromotion().getAllDependencies()) {
+      runForEveryPublisher(event, bp.getBuildType(), bp.getAssociatedBuild(), task, description, publishedRevisions);
+    }
+
+  }
+
+  private void runForEveryPublisher(@NotNull Event event, @NotNull SBuildType buildType, @NotNull SBuild build, @NotNull PublishTask task, @NotNull String description, @NotNull Set<BuildRevision> publishedRevisions) {
     if (build.isPersonal()) {
-      for(SVcsModification change: build.getBuildPromotion().getPersonalChanges()) {
+      for (SVcsModification change : build.getBuildPromotion().getPersonalChanges()) {
         if (change.isPersonal())
           return;
       }
     }
     Map<String, CommitStatusPublisher> publishers = getPublishers(buildType);
-    LOG.debug("Event: " + event.getName() + ", build " + LogUtil.describe(build) + ", publishers: " + publishers.values());
+    LOG.debug("Event: " + event.getName() + ", build " + LogUtil.describe(build) + ", publishers: " + publishers.values() + ", description: " + description);
     for (Map.Entry<String, CommitStatusPublisher> pubEntry : publishers.entrySet()) {
       CommitStatusPublisher publisher = pubEntry.getValue();
       if (!publisher.isEventSupported(event))
         continue;
       if (isPublishingDisabled(buildType)) {
-        logStatusNotPublished(event, LogUtil.describe(build), publisher, "commit status publishing is disabled");
+        logStatusNotPublished(event, description, publisher, "commit status publishing is disabled");
         continue;
       }
       List<BuildRevision> revisions = getBuildRevisionForVote(publisher, build);
       if (revisions.isEmpty()) {
-        logStatusNotPublished(event, LogUtil.describe(build), publisher, "no compatible revisions found");
+        logStatusNotPublished(event, description, publisher, "no compatible revisions found");
         continue;
       }
       myProblems.clearProblem(publisher);
-      for (BuildRevision revision: revisions) {
-        runTask(event, build.getBuildPromotion(), LogUtil.describe(build), task, publisher, revision);
+      for (BuildRevision revision : revisions) {
+        if (!publishedRevisions.contains(revision)) {
+          runTask(event, build.getBuildPromotion(), description, task, publisher, revision);
+          publishedRevisions.add(revision);
+        }
+
       }
     }
     myProblems.clearObsoleteProblems(buildType, publishers.keySet());
   }
 
   private void runForEveryPublisherQueued(@NotNull Event event, @NotNull SBuildType buildType, @NotNull SQueuedBuild build, @NotNull PublishTask task) {
+    final String description = LogUtil.describe(build);
+    Set<BuildRevision> publishedRevisions = new HashSet<BuildRevision>();
+    runForEveryPublisherQueued(event, buildType, build, task, description, publishedRevisions);
+
+    if (!isPublishingToDependenciesEnabled(buildType)) {
+      return;
+    }
+
+    for (BuildPromotion bp : build.getBuildPromotion().getAllDependencies()) {
+      runForEveryPublisherQueued(event, bp.getBuildType(), bp.getQueuedBuild(), task, description, publishedRevisions);
+    }
+  }
+
+  private void runForEveryPublisherQueued(@NotNull Event event, @NotNull SBuildType buildType, @NotNull SQueuedBuild build, @NotNull PublishTask task, @NotNull String description, @NotNull Set<BuildRevision> publishedRevisions) {
     if (build.isPersonal()) {
-      for(SVcsModification change: build.getBuildPromotion().getPersonalChanges()) {
+      for (SVcsModification change : build.getBuildPromotion().getPersonalChanges()) {
         if (change.isPersonal())
           return;
       }
@@ -233,8 +276,11 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
         continue;
       }
       myProblems.clearProblem(publisher);
-      for (BuildRevision revision: revisions) {
-        runTask(event, build.getBuildPromotion(), LogUtil.describe(build), task, publisher, revision);
+      for (BuildRevision revision : revisions) {
+        if (!publishedRevisions.contains(revision)) {
+          runTask(event, build.getBuildPromotion(), LogUtil.describe(build), task, publisher, revision);
+          publishedRevisions.add(revision);
+        }
       }
     }
     myProblems.clearObsoleteProblems(buildType, publishers.keySet());
@@ -254,10 +300,11 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
         String problemId = "commitStatusPublisher." + publisher.getId() + "." + revision.getRoot().getId();
         String problemDescription = t instanceof PublisherException ? t.getMessage() : t.toString();
         BuildProblemData buildProblem = BuildProblemData.createBuildProblem(problemId, "commitStatusPublisherProblem", problemDescription);
-        ((BuildPromotionEx)promotion).addBuildProblem(buildProblem);
+        ((BuildPromotionEx) promotion).addBuildProblem(buildProblem);
       }
     }
   }
+
   @NotNull
   private Map<String, CommitStatusPublisher> getPublishers(@NotNull SBuildType buildType) {
     Map<String, CommitStatusPublisher> publishers = new LinkedHashMap<String, CommitStatusPublisher>();

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListener.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListener.java
@@ -200,7 +200,10 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
     }
 
     for (BuildPromotion bp : build.getBuildPromotion().getAllDependencies()) {
-      runForEveryPublisher(event, bp.getBuildType(), bp.getAssociatedBuild(), task, description, publishedRevisions);
+      final SBuild associatedBuild = bp.getAssociatedBuild();
+      if (associatedBuild != null) {
+        runForEveryPublisher(event, bp.getBuildType(), associatedBuild, task, description, publishedRevisions);
+      }
     }
 
   }
@@ -249,7 +252,13 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
     }
 
     for (BuildPromotion bp : build.getBuildPromotion().getAllDependencies()) {
-      runForEveryPublisherQueued(event, bp.getBuildType(), bp.getQueuedBuild(), task, description, publishedRevisions);
+      final SQueuedBuild queuedBuild = bp.getQueuedBuild();
+      final SBuild associatedBuild = bp.getAssociatedBuild();
+      if (associatedBuild != null) {
+        runForEveryPublisher(event, bp.getBuildType(), associatedBuild, task, description, publishedRevisions);
+      } else if (queuedBuild != null) {
+        runForEveryPublisherQueued(event, bp.getBuildType(), queuedBuild, task, description, publishedRevisions);
+      }
     }
   }
 

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListenerDependencyTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListenerDependencyTest.java
@@ -1,0 +1,142 @@
+package jetbrains.buildServer.commitPublisher;
+
+import jetbrains.buildServer.buildTriggers.vcs.BuildBuilder;
+import jetbrains.buildServer.serverSide.*;
+import jetbrains.buildServer.serverSide.impl.BuildTypeImpl;
+import jetbrains.buildServer.vcs.*;
+import org.jetbrains.annotations.NotNull;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@Test
+public class CommitStatusPublisherListenerDependencyTest extends CommitStatusPublisherTestBase {
+  private BuildTypeAndPublisher myBuildTypeAndPublisher0;
+  private BuildTypeAndPublisher myBuildTypeAndPublisher1;
+  private PublisherLogger myLogger;
+  private PublisherManagerFacade myPublisherManagerFacade;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    super.setUp();
+    myLogger = new PublisherLogger();
+    myPublisherManagerFacade = new PublisherManagerFacade();
+
+    myBuildTypeAndPublisher0 = getBuildConfiguration("0");
+    myBuildTypeAndPublisher1 = getBuildConfiguration("1");
+
+    final PublisherManager myPublisherManager = myPublisherManagerFacade.getPublisherManager();
+
+    final BuildHistory history = myFixture.getHistory();
+    new CommitStatusPublisherListener(getEventDispatcher(), myPublisherManager, history, myRBManager, myProblems);
+
+    addDependency(myBuildTypeAndPublisher1.getBuildType(), myBuildTypeAndPublisher0.getBuildType());
+  }
+
+  @Test(dataProvider = "configuration")
+  public void build_with_dependency_properly_reported(Boolean configParameter, int publisher0messages, int publisher1messages) {
+    if (configParameter != null) {
+      myBuildTypeAndPublisher1.getBuildType().addParameter(new SimpleParameter("teamcity.commitStatusPublisher.publishToDependencies", configParameter.toString()));
+    }
+    startAndFinishBuild();
+
+    final MockPublisher publisher0 = myBuildTypeAndPublisher0.getPublisher();
+    final MockPublisher publisher1 = myBuildTypeAndPublisher1.getPublisher();
+
+    then(publisher0.queuedReceived()).isEqualTo(publisher0messages);
+    then(publisher0.finishedReceived()).isEqualTo(publisher0messages);
+
+    then(publisher1.queuedReceived()).isEqualTo(publisher1messages);
+    then(publisher1.finishedReceived()).isEqualTo(publisher1messages);
+  }
+
+  @DataProvider(name = "configuration")
+  public static Object[][] configuration() {
+    return new Object[][]{
+      new Object[]{null, 1, 1},  // no option defined, not published to dependency
+      new Object[]{true, 2, 1},  // option with 'true' value, published to dependency
+      new Object[]{false, 1, 1}, // option with 'false' value, not published to dependency
+    };
+  }
+
+  private BuildTypeAndPublisher getBuildConfiguration(final String index) {
+    final BuildTypeImpl buildType = registerBuildType("buildConf" + index, "MyDefaultTestProject");
+
+    final SVcsRoot vcsRoot = myFixture.addVcsRoot("jetbrains.git", "vcs" + index, buildType);
+
+    final SBuildFeatureDescriptor feature = buildType.addBuildFeature(CommitStatusPublisherFeature.TYPE, Collections.singletonMap(Constants.PUBLISHER_ID_PARAM, MockPublisherSettings.PUBLISHER_ID + index));
+
+    final MockPublisherSettings publisherSettings = new MockPublisherSettingsEx(MockPublisherSettings.PUBLISHER_ID + index);
+
+    myPublisherManagerFacade.getMyPublisherSettings().add(publisherSettings);
+
+    final MockPublisher publisher = new MockPublisher(publisherSettings, MockPublisherSettings.PUBLISHER_ID + index, buildType, feature.getId(), Collections.<String, String>emptyMap(), myProblems, myLogger);
+
+    publisherSettings.setPublisher(publisher);
+
+    prepareVcs(vcsRoot, index, "rev1_2", SetVcsRootIdMode.EXT_ID, buildType, publisher);
+
+    return new BuildTypeAndPublisher(buildType, publisher);
+  }
+
+  private void startAndFinishBuild() {
+    final BuildPromotion build1 = build().in(myBuildTypeAndPublisher1.getBuildType()).addToQueue().getBuildPromotion();
+    final SRunningBuild runningBuild1 = BuildBuilder.run(build1.getQueuedBuild(), myFixture);
+    finishBuild(runningBuild1, false);
+  }
+
+  private class BuildTypeAndPublisher {
+    private final BuildTypeImpl myBuildType;
+    private final MockPublisher myPublisher;
+
+    public BuildTypeAndPublisher(BuildTypeImpl myBuildType, MockPublisher myPublisher) {
+      this.myBuildType = myBuildType;
+      this.myPublisher = myPublisher;
+    }
+
+    public MockPublisher getPublisher() {
+      return myPublisher;
+    }
+
+    public BuildTypeImpl getBuildType() {
+      return myBuildType;
+    }
+  }
+
+  private class MockPublisherSettingsEx extends MockPublisherSettings {
+    final String myPublisherId;
+
+    public MockPublisherSettingsEx(final String publisherId) {
+      super(myProblems);
+      myPublisherId = publisherId;
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+      return myPublisherId;
+    }
+  }
+
+  private class PublisherManagerFacade {
+    private final Collection<CommitStatusPublisherSettings> myPublisherSettings;
+
+    public PublisherManagerFacade() {
+      myPublisherSettings = new ArrayList<CommitStatusPublisherSettings>();
+    }
+
+    public Collection<CommitStatusPublisherSettings> getMyPublisherSettings() {
+      return myPublisherSettings;
+    }
+
+    public PublisherManager getPublisherManager() {
+      return new PublisherManager(myPublisherSettings);
+    }
+  }
+}

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListenerDependencyTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListenerDependencyTest.java
@@ -21,6 +21,7 @@ public class CommitStatusPublisherListenerDependencyTest extends CommitStatusPub
   private BuildTypeAndPublisher myBuildTypeAndPublisher1;
   private PublisherLogger myLogger;
   private PublisherManagerFacade myPublisherManagerFacade;
+  private MockPublisher mySecondPublisher;
 
   @BeforeMethod
   public void setUp() throws Exception {
@@ -30,6 +31,7 @@ public class CommitStatusPublisherListenerDependencyTest extends CommitStatusPub
 
     myBuildTypeAndPublisher0 = getBuildConfiguration("0");
     myBuildTypeAndPublisher1 = getBuildConfiguration("1");
+    mySecondPublisher = createPublisher(myBuildTypeAndPublisher1.getBuildType(), "2");
 
     final PublisherManager myPublisherManager = myPublisherManagerFacade.getPublisherManager();
 
@@ -54,6 +56,9 @@ public class CommitStatusPublisherListenerDependencyTest extends CommitStatusPub
 
     then(publisher1.queuedReceived()).isEqualTo(publisher1messages);
     then(publisher1.finishedReceived()).isEqualTo(publisher1messages);
+
+    then(mySecondPublisher.queuedReceived()).isEqualTo(publisher1messages);
+    then(mySecondPublisher.finishedReceived()).isEqualTo(publisher1messages);
   }
 
   @DataProvider(name = "configuration")
@@ -70,6 +75,14 @@ public class CommitStatusPublisherListenerDependencyTest extends CommitStatusPub
 
     final SVcsRoot vcsRoot = myFixture.addVcsRoot("jetbrains.git", "vcs" + index, buildType);
 
+    MockPublisher publisher = createPublisher(buildType, index);
+
+    prepareVcs(vcsRoot, index, "rev1_2", SetVcsRootIdMode.EXT_ID, buildType, publisher);
+
+    return new BuildTypeAndPublisher(buildType, publisher);
+  }
+
+  private MockPublisher createPublisher(SBuildType buildType, String index) {
     final SBuildFeatureDescriptor feature = buildType.addBuildFeature(CommitStatusPublisherFeature.TYPE, Collections.singletonMap(Constants.PUBLISHER_ID_PARAM, MockPublisherSettings.PUBLISHER_ID + index));
 
     final MockPublisherSettings publisherSettings = new MockPublisherSettingsEx(MockPublisherSettings.PUBLISHER_ID + index);
@@ -80,9 +93,7 @@ public class CommitStatusPublisherListenerDependencyTest extends CommitStatusPub
 
     publisherSettings.setPublisher(publisher);
 
-    prepareVcs(vcsRoot, index, "rev1_2", SetVcsRootIdMode.EXT_ID, buildType, publisher);
-
-    return new BuildTypeAndPublisher(buildType, publisher);
+    return publisher;
   }
 
   private void startAndFinishBuild() {

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListenerTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListenerTest.java
@@ -1,8 +1,11 @@
 package jetbrains.buildServer.commitPublisher;
 
+import jetbrains.buildServer.RunningBuild;
+import jetbrains.buildServer.buildTriggers.vcs.BuildBuilder;
 import jetbrains.buildServer.messages.Status;
 import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.serverSide.impl.BuildPromotionImpl;
+import jetbrains.buildServer.serverSide.impl.BuildTypeImpl;
 import jetbrains.buildServer.serverSide.systemProblems.SystemProblem;
 import jetbrains.buildServer.serverSide.systemProblems.SystemProblemEntry;
 import jetbrains.buildServer.util.Dates;
@@ -219,23 +222,9 @@ public class CommitStatusPublisherListenerTest extends CommitStatusPublisherTest
    prepareVcs("vcs1", "111", "rev1_2", SetVcsRootIdMode.EXT_ID);
   }
 
-  private void prepareVcs(String vcsRootName, String currentVersion, String revNo, SetVcsRootIdMode setVcsRootIdMode) {
+  private void prepareVcs(String vcsRootName, String currentVersion, String revNo, SetVcsRootIdMode setVcsRootIdMode)
+  {
     final SVcsRoot vcsRoot = myFixture.addVcsRoot("jetbrains.git", vcsRootName);
-    switch (setVcsRootIdMode) {
-      case EXT_ID:
-        myPublisher.setVcsRootId(vcsRoot.getExternalId());
-        break;
-      case INT_ID:
-        myPublisher.setVcsRootId(String.valueOf(vcsRoot.getId()));
-    }
-    myBuildType.addVcsRoot(vcsRoot);
-    VcsRootInstance vcsRootInstance = myBuildType.getVcsRootInstances().iterator().next();
-    myCurrentVersions.put(vcsRoot.getName(), currentVersion);
-    myFixture.addModification(new ModificationData(new Date(),
-            Collections.singletonList(new VcsChange(VcsChangeInfo.Type.CHANGED, "changed", "file", "file","1", "2")),
-            "descr2", "user", vcsRootInstance, revNo, revNo));
+    prepareVcs(vcsRoot, currentVersion, revNo, setVcsRootIdMode, myBuildType, myPublisher);
   }
-
-
-  private enum SetVcsRootIdMode { DONT, EXT_ID, INT_ID }
 }

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherTestBase.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherTestBase.java
@@ -1,6 +1,7 @@
 package jetbrains.buildServer.commitPublisher;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -76,8 +77,23 @@ public class CommitStatusPublisherTestBase extends BaseServerTestCase {
     extensionHolder.registerExtension(BuildFeature.class, CommitStatusPublisherFeature.TYPE, myFeature);
   }
 
+  protected enum SetVcsRootIdMode { DONT, EXT_ID, INT_ID }
 
-
+  protected void prepareVcs(SVcsRoot vcsRoot, String currentVersion, String revNo, SetVcsRootIdMode setVcsRootIdMode, BuildTypeEx buildType, MockPublisher publisher) {
+    switch (setVcsRootIdMode) {
+      case EXT_ID:
+        publisher.setVcsRootId(vcsRoot.getExternalId());
+        break;
+      case INT_ID:
+        publisher.setVcsRootId(String.valueOf(vcsRoot.getId()));
+    }
+    buildType.addVcsRoot(vcsRoot);
+    VcsRootInstance vcsRootInstance = buildType.getVcsRootInstances().iterator().next();
+    myCurrentVersions.put(vcsRoot.getName(), currentVersion);
+    myFixture.addModification(new ModificationData(new Date(),
+      Collections.singletonList(new VcsChange(VcsChangeInfo.Type.CHANGED, "changed", "file", "file","1", "2")),
+      "descr2", "user", vcsRootInstance, revNo, revNo));
+  }
 
   private class MockWebControllerManager implements WebControllerManager {
 

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/MockPublisher.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/MockPublisher.java
@@ -23,6 +23,7 @@ class MockPublisher extends BaseCommitStatusPublisher implements CommitStatusPub
   private int mySuccessReceived = 0;
   private int myStartedReceived = 0;
   private int myCommentedReceived = 0;
+  private int myQueuedReceived = 0;
   private String myLastComment = null;
 
   private boolean myShouldThrowException = false;
@@ -70,8 +71,16 @@ class MockPublisher extends BaseCommitStatusPublisher implements CommitStatusPub
 
   int successReceived() { return mySuccessReceived; }
 
+  int queuedReceived() { return myQueuedReceived; }
+
   void shouldThrowException() {myShouldThrowException = true; }
   void shouldReportError() {myShouldReportError = true; }
+
+  @Override
+  public boolean buildQueued(@NotNull SQueuedBuild build, @NotNull BuildRevision revision) throws PublisherException {
+    myQueuedReceived++;
+    return true;
+  }
 
   @Override
   public boolean buildStarted(@NotNull final SRunningBuild build, @NotNull final BuildRevision revision) throws PublisherException {


### PR DESCRIPTION
This feature is to cover usecase where we have complex build chain of components in different VCS and PR in any of them can be merged only when verification build at the end of chain passes.