### PR TITLE
Add GitLab support to publish queued builds

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
@@ -24,6 +24,8 @@ public class GitlabSettings extends BasePublisherSettings implements CommitStatu
   private static final Pattern URL_WITH_API_SUFFIX = Pattern.compile("(.*)/api/v.");
 
   private static final Set<Event> mySupportedEvents = new HashSet<Event>() {{
+    add(Event.QUEUED);
+    add(Event.REMOVED_FROM_QUEUE);
     add(Event.STARTED);
     add(Event.FINISHED);
     add(Event.MARKED_AS_SUCCESSFUL);

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisherTest.java
@@ -32,8 +32,8 @@ public class GitlabPublisherTest extends HttpPublisherTest {
   private static final String GROUP_REPO = "group_repo";
 
   public GitlabPublisherTest() {
-    myExpectedRegExps.put(EventToTest.QUEUED, null); // not to be tested
-    myExpectedRegExps.put(EventToTest.REMOVED, null); // not to be tested
+    myExpectedRegExps.put(EventToTest.QUEUED, String.format(".*/projects/owner%%2Fproject/statuses/%s.*ENTITY:.*pending.*Build queued.*", REVISION));
+    myExpectedRegExps.put(EventToTest.REMOVED, String.format(".*/projects/owner%%2Fproject/statuses/%s.*ENTITY:.*canceled.*Build canceled.*", REVISION));
     myExpectedRegExps.put(EventToTest.STARTED, String.format(".*/projects/owner%%2Fproject/statuses/%s.*ENTITY:.*running.*Build started.*", REVISION));
     myExpectedRegExps.put(EventToTest.FINISHED, String.format(".*/projects/owner%%2Fproject/statuses/%s.*ENTITY:.*success.*Success.*", REVISION));
     myExpectedRegExps.put(EventToTest.FAILED, String.format(".*/projects/owner%%2Fproject/statuses/%s.*ENTITY:.*failed.*Failure.*", REVISION));


### PR DESCRIPTION
This adds in support for publishing queued and canceled builds for the GitLab publisher.

Because TeamCity does build pipeline optimization and queues builds before deciding they don't need to be rebuilt, there needed to be some logic in here to handle those cases and publish the appropriate completed status back to GitLab if a queued build was optimized out of the queue.

There are potentially some other edge cases around multiple builds occurring on the same commit at the same time, but we've been using these changes heavily at our company for at least a few months now and haven't seen any major issues.