### PR TITLE
Add ability to publish status to dependencies

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/BaseCommitStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/BaseCommitStatusPublisher.java
@@ -3,6 +3,7 @@ package jetbrains.buildServer.commitPublisher;
 import com.google.common.util.concurrent.Striped;
 import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.users.User;
+import jetbrains.buildServer.util.StringUtil;
 import jetbrains.buildServer.vcs.VcsRoot;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -88,6 +89,26 @@ public abstract class BaseCommitStatusPublisher implements CommitStatusPublisher
   public boolean isPublishingForRevision(@NotNull final BuildRevision revision) {
     VcsRoot vcsRoot = revision.getRoot();
     return getSettings().isPublishingForVcsRoot(vcsRoot);
+  }
+
+  public boolean isDependencyPublishingEnabled() {
+    final String publishPullRequest = StringUtil.emptyIfNull(myParams.get(Constants.PUBLISH_TO_DEPENDENCIES)).trim();
+    return Boolean.valueOf(publishPullRequest);
+  }
+
+  public boolean isPublishingUnmatchedBranchesEnabled() {
+    final String publishPullRequest = StringUtil.emptyIfNull(myParams.get(Constants.PUBLISH_TO_UNMATCHED_BRANCHES)).trim();
+    return Boolean.valueOf(publishPullRequest);
+  }
+
+  @Nullable
+  public String getDependencyPublishingWhitelistPattern() {
+    return myParams.get(Constants.PUBLISH_TO_DEPENDENCIES_WHITELIST);
+  }
+
+  @Nullable
+  public String getDependencyPublishingBlacklistPattern() {
+    return myParams.get(Constants.PUBLISH_TO_DEPENDENCIES_BLACKLIST);
   }
 
   public boolean isEventSupported(Event event) {

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisher.java
@@ -43,6 +43,16 @@ public interface CommitStatusPublisher {
 
   boolean isPublishingForRevision(@NotNull BuildRevision revision);
 
+  boolean isDependencyPublishingEnabled();
+
+  boolean isPublishingUnmatchedBranchesEnabled();
+
+  @Nullable
+  String getDependencyPublishingWhitelistPattern();
+
+  @Nullable
+  String getDependencyPublishingBlacklistPattern();
+
   void setConnectionTimeout(int timeout);
 
   boolean isEventSupported(Event event);

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListener.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherListener.java
@@ -8,6 +8,7 @@ import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.serverSide.impl.LogUtil;
 import jetbrains.buildServer.users.User;
 import jetbrains.buildServer.util.EventDispatcher;
+import jetbrains.buildServer.util.StringUtil;
 import jetbrains.buildServer.vcs.SVcsModification;
 import jetbrains.buildServer.vcs.SVcsRoot;
 import org.jetbrains.annotations.NotNull;
@@ -18,6 +19,7 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
 
   private final static Logger LOG = Logger.getInstance(CommitStatusPublisherListener.class.getName());
   private final static String PUBLISHING_ENABLED_PROPERTY_NAME = "teamcity.commitStatusPublisher.enabled";
+  private final static String PUBLISHING_TO_DEPENDENCIES_ENABLED_PROPERTY_NAME = "teamcity.commitStatusPublisher.publishToDependencies";
 
   private final PublisherManager myPublisherManager;
   private final BuildHistory myBuildHistory;
@@ -179,6 +181,11 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
                 || "true".equals(publishingEnabledParam));
   }
 
+  private boolean isPublishingToDependenciesEnabled(SBuildType buildType) {
+    String publishingEnabledParam = buildType.getParameterValue(PUBLISHING_TO_DEPENDENCIES_ENABLED_PROPERTY_NAME);
+    return StringUtil.areEqualIgnoringCase("true", publishingEnabledParam);
+  }
+
   private void logStatusNotPublished(@NotNull Event event, @NotNull String buildDescription, @NotNull CommitStatusPublisher publisher, @NotNull String message) {
     LOG.info(String.format("Event: %s, build %s, publisher %s: %s", event.getName(), buildDescription, publisher.toString(), message));
   }
@@ -204,17 +211,34 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
         logStatusNotPublished(event, LogUtil.describe(build), publisher, "commit status publishing is disabled");
         continue;
       }
-      List<BuildRevision> revisions = getBuildRevisionForVote(publisher, build);
-      if (revisions.isEmpty()) {
-        logStatusNotPublished(event, LogUtil.describe(build), publisher, "no compatible revisions found");
-        continue;
-      }
-      myProblems.clearProblem(publisher);
-      for (BuildRevision revision: revisions) {
-        runTask(event, build.getBuildPromotion(), LogUtil.describe(build), task, publisher, revision);
-      }
+      runForPublisher(event, build, task, publisher, isPublishingToDependenciesEnabled(buildType));
     }
     myProblems.clearObsoleteProblems(buildType, publishers.keySet());
+  }
+
+  private void runForPublisher(@NotNull Event event,
+                               @NotNull SBuild build,
+                               @NotNull PublishTask task,
+                               @NotNull CommitStatusPublisher publisher,
+                               boolean publishDependencies) {
+    if (publishDependencies) {
+      for (BuildPromotion bp : build.getBuildPromotion().getAllDependencies()) {
+        final SBuild associatedBuild = bp.getAssociatedBuild();
+        if (associatedBuild != null) {
+          runForPublisher(event, associatedBuild, task, publisher, true);
+        }
+      }
+    }
+
+    List<BuildRevision> revisions = getBuildRevisionForVote(publisher, build);
+    if (revisions.isEmpty()) {
+      logStatusNotPublished(event, LogUtil.describe(build), publisher, "no compatible revisions found");
+      return;
+    }
+    myProblems.clearProblem(publisher);
+    for (BuildRevision revision: revisions) {
+      runTask(event, build.getBuildPromotion(), LogUtil.describe(build), task, publisher, revision);
+    }
   }
 
   private void runForEveryPublisherQueued(@NotNull Event event, @NotNull SBuildType buildType, @NotNull SQueuedBuild build, @NotNull PublishTask task) {
@@ -238,17 +262,38 @@ public class CommitStatusPublisherListener extends BuildServerAdapter {
         logStatusNotPublished(event, LogUtil.describe(build), publisher, "commit status publishing is disabled");
         continue;
       }
-      List<BuildRevision> revisions = getQueuedBuildRevisionForVote(buildType, publisher, build);
-      if (revisions.isEmpty()) {
-        logStatusNotPublished(event, LogUtil.describe(build), publisher, "no compatible revisions found");
-        continue;
-      }
-      myProblems.clearProblem(publisher);
-      for (BuildRevision revision: revisions) {
-        runTask(event, build.getBuildPromotion(), LogUtil.describe(build), task, publisher, revision);
-      }
+      runForPublisherQueued(event, buildType, build, task, publisher, isPublishingToDependenciesEnabled(buildType));
     }
     myProblems.clearObsoleteProblems(buildType, publishers.keySet());
+  }
+
+  private void runForPublisherQueued(@NotNull Event event,
+                                     @NotNull SBuildType buildType,
+                                     @NotNull SQueuedBuild build,
+                                     @NotNull PublishTask task,
+                                     @NotNull CommitStatusPublisher publisher,
+                                     boolean publishDependencies) {
+    if (publishDependencies) {
+      for (BuildPromotion bp : build.getBuildPromotion().getAllDependencies()) {
+        final SQueuedBuild queuedBuild = bp.getQueuedBuild();
+        final SBuild associatedBuild = bp.getAssociatedBuild();
+        if (associatedBuild != null) {
+          runForPublisher(event, associatedBuild, task, publisher, true);
+        } else if (queuedBuild != null && bp.getBuildType() != null) {
+          runForPublisherQueued(event, bp.getBuildType(), queuedBuild, task, publisher, true);
+        }
+      }
+    }
+
+    List<BuildRevision> revisions = getQueuedBuildRevisionForVote(buildType, publisher, build);
+    if (revisions.isEmpty()) {
+      logStatusNotPublished(event, LogUtil.describe(build), publisher, "no compatible revisions found");
+      return;
+    }
+    myProblems.clearProblem(publisher);
+    for (BuildRevision revision: revisions) {
+      runTask(event, build.getBuildPromotion(), LogUtil.describe(build), task, publisher, revision);
+    }
   }
 
   private void runTask(@NotNull Event event,

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/Constants.java
@@ -10,6 +10,11 @@ public class Constants {
   public static final String VCS_ROOT_ID_PARAM = "vcsRootId";
   public static final String PUBLISHER_ID_PARAM = "publisherId";
 
+  public static final String PUBLISH_TO_DEPENDENCIES = "publishToDependencies";
+  public static final String PUBLISH_TO_UNMATCHED_BRANCHES = "publishToUnmatchedBranches";
+  public static final String PUBLISH_TO_DEPENDENCIES_WHITELIST = "publishToDependenciesWhitelist";
+  public static final String PUBLISH_TO_DEPENDENCIES_BLACKLIST = "publishToDependenciesBlacklist";
+
   public static final String PASSWORD_PARAMETER_TYPE = "password";
   public static final String TEST_CONNECTION_PARAM = "testconnection";
   public static final String TEST_CONNECTION_YES = "yes";
@@ -64,6 +69,26 @@ public class Constants {
   @NotNull
   public String getPublisherIdParam() {
     return PUBLISHER_ID_PARAM;
+  }
+
+  @NotNull
+  public String getPublishToDependencies() {
+    return PUBLISH_TO_DEPENDENCIES;
+  }
+
+  @NotNull
+  public String getPublishToUnmatchedBranches() {
+    return PUBLISH_TO_UNMATCHED_BRANCHES;
+  }
+
+  @NotNull
+  public String getPublishToDependenciesWhitelistPattern() {
+    return PUBLISH_TO_DEPENDENCIES_WHITELIST;
+  }
+
+  @NotNull
+  public String getPublishToDependenciesBlacklistPattern() {
+    return PUBLISH_TO_DEPENDENCIES_BLACKLIST;
   }
 
   @NotNull

--- a/commit-status-publisher-server/src/main/resources/buildServerResources/publisherFeatureHeader.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/publisherFeatureHeader.jsp
@@ -107,6 +107,50 @@
         publishing statuses for commits in all attached VCS roots.</span>
     </td>
   </tr>
+
+  <tr class="advancedSetting">
+    <th>Options:</th>
+    <td>
+      <props:checkboxProperty name="${constants.publishToDependencies}"/>
+      <label for="${constants.publishToDependencies}">Publish to dependencies</label>
+      <span class="smallNote">
+        This will publish the status of this build configuration to all dependent build configurations in the build chain.
+      </span>
+    </td>
+  </tr>
+
+  <tr class="advancedSetting">
+    <th></th>
+    <td>
+      <props:checkboxProperty name="${constants.publishToUnmatchedBranches}"/>
+      <label for="${constants.publishToUnmatchedBranches}">Publish to unmatched branches</label>
+      <span class="smallNote">
+          This option will publish commit status to default branches even if the build was triggered by a non matching
+          branch of another dependency in the build chain.
+        </span>
+    </td>
+  </tr>
+
+  <tr class="advancedSetting">
+    <th><label for="${constants.publishToDependenciesWhitelistPattern}">Dependency Whitelist Pattern: </label></th>
+    <td>
+      <props:textProperty name="${constants.publishToDependenciesWhitelistPattern}" className="longField"/>
+      <span class="smallNote">
+        Optional regex of the git repository urls to whitelist when publishing to dependencies.
+      </span>
+    </td>
+  </tr>
+
+  <tr class="advancedSetting">
+    <th><label for="${constants.publishToDependenciesBlacklistPattern}">Dependency Blacklist Pattern: </label></th>
+    <td>
+      <props:textProperty name="${constants.publishToDependenciesBlacklistPattern}" className="longField"/>
+      <span class="smallNote">
+          Optional regex of the git repository urls to blacklist when publishing to dependencies.
+        </span>
+    </td>
+  </tr>
+
   <tr>
     <th>
       <label for="${constants.publisherIdParam}">Publisher:<l:star/></label>


### PR DESCRIPTION
This is similar to PR #37 but done more similarly to the approach that was decided in the comments that caused that pull request to be closed.

This allows a single commit status publisher to publish its status to dependencies in the build chain. By default if enabled it will publish the status to all dependencies in the chain but it also has the ability to specify a regex whitelist and blacklist to filter out certain dependencies that you may not want the status published to.

It also has the ability to exclude publishing to the default branch of dependencies if the job running on the child job is not the default branch.  For example if "feature-1234" is running on a child job, and the dependency has no matching branch named "feature-1234", it will not publish back to the default branch that was pulled.  This prevents a dependency's default branch from continually getting its status changed for feature branches of a child job.

The whitelist/blacklist and the default branch matching are restricted to just git repositories because I don't have any other repository types to test with.