### PR TITLE
TW-56395 Support for Bitbucket Smart Mirror SSH configured VCS roots

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/GitRepositoryParser.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/GitRepositoryParser.java
@@ -23,17 +23,14 @@ public class GitRepositoryParser {
   public static Repository parseRepository(@NotNull String uri, @Nullable String pathPrefix) {
 
     Matcher m = GIT_URL_PATTERN.matcher(uri);
-    if (m.matches())
-      if (m.group(1).toLowerCase().startsWith("http")) {
-        return getRepositoryInfo(m.group(2), m.group(3), pathPrefix);
-      } else {
-        return getRepositoryInfo(m.group(2), m.group(3), "");
-      }
+    if (m.matches()){
+      return getRepositoryInfo(m.group(2), m.group(3), pathPrefix);
+    }
     m = PROTOCOL_PREFIX_PATTERN.matcher(uri);
     if (!m.matches()) {
       m = GIT_SCP_PATTERN.matcher(uri);
       if (m.matches()) {
-        return getRepositoryInfo(m.group(1), m.group(2), "");
+        return getRepositoryInfo(m.group(1), m.group(2), pathPrefix);
       }
     }
     LOG.warn("Cannot parse Git repository url " + uri);

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/GitRepositoryParserTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/GitRepositoryParserTest.java
@@ -31,27 +31,27 @@ public class GitRepositoryParserTest {
 
   @TestFor(issues = "TW-49264")
   public void parse_ssh_urls_with_slashes_and_path() {
-    parse_ssh_urls_ex("one/two/three", "/somepath/morepath");
+    parse_ssh_urls_ex("one/two/three", "somepath/morepath/");
   }
 
   private void parse_ssh_urls_ex(String owner, String vcsRootPath) {
     List<String> urls = Arrays.asList(
-            "git@gitlab.com:%s/repository.git",
-            "git@github.com:/%s/repository.git",
-            "git@github.com:/%s/repository.git/",
-            "non_standard_name@github.com:%s/repository.git",
-            "git.mygithubserver.com:%s/repository.git/",
-            "ssh://git@github.com:%s/repository.git",
-            "ssh://git@github.com:%s/repository.git/",
-            "ssh://non_standard_name@github.com:%s/repository.git",
-            "ssh://git@bitbucket.org/%s/repository.git",
-            "ssh://git@bitbucket.org/%s/repository",
-            "ssh://git@altssh.bitbucket.org:443/%s/repository.git",
-            "ssh://bitbucket.org/%s/repository",
-            "ssh://bitbucket.org/%s/repository/");
+            "git@gitlab.com:%s%s/repository.git",
+            "git@github.com:/%s%s/repository.git",
+            "git@github.com:/%s%s/repository.git/",
+            "non_standard_name@github.com:%s%s/repository.git",
+            "git.mygithubserver.com:%s%s/repository.git/",
+            "ssh://git@github.com:%s%s/repository.git",
+            "ssh://git@github.com:%s%s/repository.git/",
+            "ssh://non_standard_name@github.com:%s%s/repository.git",
+            "ssh://git@bitbucket.org/%s%s/repository.git",
+            "ssh://git@bitbucket.org/%s%s/repository",
+            "ssh://git@altssh.bitbucket.org:443/%s%s/repository.git",
+            "ssh://bitbucket.org/%s%s/repository",
+            "ssh://bitbucket.org/%s%s/repository/");
 
     for(String url : urls) {
-      String urlWithOwner = String.format(url, owner);
+      String urlWithOwner = String.format(url, null == vcsRootPath ? "" : vcsRootPath, owner);
       Repository repo = null == vcsRootPath ? GitRepositoryParser.parseRepository(urlWithOwner)
                                             : GitRepositoryParser.parseRepository(urlWithOwner, vcsRootPath);
       then(repo).overridingErrorMessage("Failed to parse url " + urlWithOwner).isNotNull();


### PR DESCRIPTION
As per https://youtrack.jetbrains.com/issue/TW-56395, these changes are proposed to fix the issue with using Bitbucket Smart Mirror SSH VCS roots with the plugin. Bitbucket Smart Mirror SSH VCS roots contain an additional path which is not strip when calling the REST API and causes the plugin to fail to connect.

These changes extend the tests to include sub-paths and changes to the parsing if the VCS root URL to strip the additional paths.