### PR TITLE
github: update build as soon as failure is detected

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/GitHubPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/github/GitHubPublisher.java
@@ -53,6 +53,12 @@ class GitHubPublisher extends BaseCommitStatusPublisher {
   }
 
   @Override
+  public boolean buildFailureDetected(@NotNull SRunningBuild build, @NotNull BuildRevision revision) throws PublisherException {
+    updateBuildStatus(build, revision, false);
+    return true;
+  }
+
+  @Override
   public boolean buildMarkedAsSuccessful(@NotNull final SBuild build, @NotNull final BuildRevision revision, final boolean buildInProgress) throws PublisherException {
     updateBuildStatus(build, revision, buildInProgress);
     return true;


### PR DESCRIPTION
The GitHub plugin doesn't update commit status until a build is completely finished. If it's marked as failed, it should update ASAP.