### PR TITLE
Fixed subgroups breaking gitlab status publishing

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabSettings.java
@@ -137,7 +137,7 @@ public class GitlabSettings extends BasePublisherSettings implements CommitStatu
 
   @NotNull
   public static String getProjectsUrl(@NotNull String apiUrl, @NotNull String owner, @NotNull String repo) {
-    return apiUrl + "/projects/" + owner.replace(".", "%2E").replace("/", "%2F") + "%2F" + repo.replace(".", "%2E");
+    return apiUrl + "/projects/" + owner.replace(".", "%2E").replace("/", "%2F") + "%2F" + repo.replace(".", "%2E").replace("/", "%2F");
   }
 
   @NotNull


### PR DESCRIPTION
A / in repo name would cause 404 as gitlab expects encoded repo names. Having a project in a subgroup was adding a / to repo name.