### PR TITLE
Remove hash mark from build number

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
@@ -375,7 +375,7 @@ class TfsStatusPublisher extends HttpBasedCommitStatusPublisher {
 
     final StatusState state = getState(isStarting, build.getBuildStatus());
     status.state = state;
-    status.description = String.format("The build %s #%s %s %s",
+    status.description = String.format("The build %s %s %s %s",
       build.getFullName(), build.getBuildNumber(),
       isStarting ? "is" : "has", state.toString().toLowerCase());
     status.targetURL = myLinks.getViewResultsUrl(build);


### PR DESCRIPTION
Removes hash mark from TFS pull request status description.

TFS has a weird bug which pollutes work items history with links to irrelevant pull requests:
https://developercommunity.visualstudio.com/content/problem/487210/tfs-treats-build-number-in-custom-pull-requests-st.html

As long as @microsoft insists that this is not a bug, I suggest to remove hash mark as the most convenient workaround.

Btw: having hash sign in front of custom build number format quite often makes no sense.