### PR TITLE
Fix ref/pull/###/merge at same position as source

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/tfs/TfsStatusPublisher.java
@@ -209,7 +209,9 @@ class TfsStatusPublisher extends HttpBasedCommitStatusPublisher {
       LOG.debug(message, e);
       throw new PublisherException(message, e);
     }
-
+    
+    commits.add(parentCommitId); //include the merge commit in-case the head of the merge branch is the same as source
+      
     return commits;
   }
 


### PR DESCRIPTION
Had an issue where the head of the merge request was at the same location as the source so the status was posted to the previous iteration.