### PR TITLE
TW-48863 Fix queued events

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/BaseCommitStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/BaseCommitStatusPublisher.java
@@ -64,7 +64,7 @@ public abstract class BaseCommitStatusPublisher implements CommitStatusPublisher
     return false;
   }
 
-  public boolean buildRemovedFromQueue(@NotNull SQueuedBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) throws PublisherException {
+  public boolean buildRemovedFromQueue(@NotNull SBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) throws PublisherException {
     return false;
   }
 

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisher.java
@@ -26,7 +26,7 @@ public interface CommitStatusPublisher {
 
   boolean buildQueued(@NotNull SQueuedBuild build, @NotNull BuildRevision revision) throws PublisherException;
 
-  boolean buildRemovedFromQueue(@NotNull SQueuedBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) throws PublisherException;
+  boolean buildRemovedFromQueue(@NotNull SBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) throws PublisherException;
 
   boolean buildStarted(@NotNull SBuild build, @NotNull BuildRevision revision) throws PublisherException;
 

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
@@ -72,7 +72,7 @@ class GitlabPublisher extends HttpBasedCommitStatusPublisher {
   }
 
   @Override
-  public boolean buildRemovedFromQueue(@NotNull SQueuedBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) throws PublisherException {
+  public boolean buildRemovedFromQueue(@NotNull SBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) throws PublisherException {
     publish(build, revision, GitlabBuildStatus.CANCELED, "Build canceled");
     return true;
   }

--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/stash/StashPublisher.java
@@ -66,7 +66,7 @@ class StashPublisher extends HttpBasedCommitStatusPublisher {
   }
 
   @Override
-  public boolean buildRemovedFromQueue(@NotNull SQueuedBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) {
+  public boolean buildRemovedFromQueue(@NotNull SBuild build, @NotNull BuildRevision revision, @Nullable User user, @Nullable String comment) {
     StringBuilder description = new StringBuilder("Build removed from queue");
     if (user != null)
       description.append(" by ").append(user.getName());

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/CommitStatusPublisherTest.java
@@ -26,6 +26,7 @@ import jetbrains.buildServer.messages.Status;
 import jetbrains.buildServer.serverSide.BuildRevision;
 import jetbrains.buildServer.serverSide.SBuildType;
 import jetbrains.buildServer.serverSide.SFinishedBuild;
+import jetbrains.buildServer.serverSide.SQueuedBuild;
 import jetbrains.buildServer.serverSide.SRunningBuild;
 import jetbrains.buildServer.serverSide.impl.BaseServerTestCase;
 import jetbrains.buildServer.serverSide.oauth.OAuthConnectionsManager;
@@ -153,7 +154,9 @@ public abstract class CommitStatusPublisherTest extends BaseServerTestCase {
 
   public void test_buildRemovedFromQueue()  throws Exception {
     if (isSkipEvent(EventToTest.REMOVED)) return;
-    myPublisher.buildRemovedFromQueue(myBuildType.addToQueue(""), myRevision, myUser, COMMENT);
+    SQueuedBuild queuedBuild = myBuildType.addToQueue("");
+    queuedBuild.removeFromQueue(myUser, COMMENT);
+    myPublisher.buildRemovedFromQueue(queuedBuild.getBuildPromotion().getAssociatedBuild(), myRevision, myUser, COMMENT);
     then(getRequestAsString()).isNotNull().matches(myExpectedRegExps.get(EventToTest.REMOVED));
   }
 

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/MockPublisher.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/MockPublisher.java
@@ -91,6 +91,8 @@ class MockPublisher extends BaseCommitStatusPublisher implements CommitStatusPub
     return myType;
   }
 
+  int failuresReceived() { return myFailuresReceived; }
+
   int successReceived() { return mySuccessReceived; }
 
   void shouldThrowException() {myShouldThrowException = true; }
@@ -117,7 +119,7 @@ class MockPublisher extends BaseCommitStatusPublisher implements CommitStatusPub
   }
 
   @Override
-  public boolean buildRemovedFromQueue(@NotNull final SQueuedBuild build, @NotNull final BuildRevision revision, @Nullable final User user, @Nullable final String comment)
+  public boolean buildRemovedFromQueue(@NotNull final SBuild build, @NotNull final BuildRevision revision, @Nullable final User user, @Nullable final String comment)
     throws PublisherException {
     pretendToHandleEvent(Event.REMOVED_FROM_QUEUE);
     return true;

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/BaseStashPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/BaseStashPublisherTest.java
@@ -40,6 +40,7 @@ public abstract class BaseStashPublisherTest extends HttpPublisherTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
+    setInternalProperty(StashPublisher.PROP_PUBLISH_QUEUED_BUILD_STATUS, true);
     Map<String, String> params = getPublisherParams();
     myPublisherSettings = new StashSettings(new MockPluginDescriptor(), myWebLinks, myProblems, myTrustStoreProvider);
     myPublisher = new StashPublisher(myPublisherSettings, myBuildType, FEATURE_ID, myWebLinks, params, myProblems);

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/BitbucketServer74PublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/BitbucketServer74PublisherTest.java
@@ -24,8 +24,8 @@ public class BitbucketServer74PublisherTest extends BaseStashPublisherTest {
 
   public BitbucketServer74PublisherTest() {
     myServerVersion = "7.4";
-    myExpectedRegExps.put(EventToTest.QUEUED, null); // not to be tested
-    myExpectedRegExps.put(EventToTest.REMOVED, null);  // not to be tested
+    myExpectedRegExps.put(EventToTest.QUEUED, String.format(".*projects/owner/repos/project/commits/%s.*ENTITY:.*Build queued.*INPROGRESS.*", REVISION));
+    myExpectedRegExps.put(EventToTest.REMOVED, String.format(".*projects/owner/repos/project/commits/%s.*ENTITY:.*Build removed from queue.*FAILED.*", REVISION));
     myExpectedRegExps.put(EventToTest.STARTED, String.format(".*projects/owner/repos/project/commits/%s.*ENTITY:.*Build started.*INPROGRESS.*", REVISION));
     myExpectedRegExps.put(EventToTest.FINISHED, String.format(".*projects/owner/repos/project/commits/%s.*ENTITY:.*Success.*SUCCESSFUL.*", REVISION));
     myExpectedRegExps.put(EventToTest.FAILED, String.format(".*projects/owner/repos/project/commits/%s.*ENTITY:.*Failure.*FAILED.*", REVISION));

--- a/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/StashPublisherTest.java
+++ b/commit-status-publisher-server/src/test/java/jetbrains/buildServer/commitPublisher/stash/StashPublisherTest.java
@@ -24,8 +24,8 @@ public class StashPublisherTest extends BaseStashPublisherTest {
 
   public StashPublisherTest() {
     myServerVersion = "6.0";
-    myExpectedRegExps.put(EventToTest.QUEUED, null); // not to be tested
-    myExpectedRegExps.put(EventToTest.REMOVED, null);  // not to be tested
+    myExpectedRegExps.put(EventToTest.QUEUED, String.format(".*build-status/.*/commits/%s.*ENTITY:.*INPROGRESS.*Build queued.*", REVISION));
+    myExpectedRegExps.put(EventToTest.REMOVED, String.format(".*build-status/.*/commits/%s.*ENTITY:.*FAILED.*Build removed from queue.*", REVISION));
     myExpectedRegExps.put(EventToTest.STARTED, String.format(".*build-status/.*/commits/%s.*ENTITY:.*INPROGRESS.*Build started.*", REVISION));
     myExpectedRegExps.put(EventToTest.FINISHED, String.format(".*build-status/.*/commits/%s.*ENTITY:.*SUCCESSFUL.*Success.*", REVISION));
     myExpectedRegExps.put(EventToTest.FAILED, String.format(".*build-status/.*/commits/%s.*ENTITY:.*FAILED.*Failure.*", REVISION));


### PR DESCRIPTION
Enabling the "publish commit status on adding to queue" feature partially worked, but there were two scenarios that led to builds being stuck in "pending" status forever:

- Being canceled from the queue
- Being optimized to another build

This commit fixes these scenarios by publishing "failure" if canceled from the queue (which is consistent with the behavior of a canceled running build), and delegating to the replacement build's status upon queue optimization (which is consistent with the actual status of the build chain).

See also #21