### PR TITLE
Send full ref if not a branch or tag

### DIFF
--- a/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
+++ b/commit-status-publisher-server/src/main/java/jetbrains/buildServer/commitPublisher/gitlab/GitlabPublisher.java
@@ -42,6 +42,7 @@ class GitlabPublisher extends HttpBasedCommitStatusPublisher<GitlabBuildStatus> 
   private static final String STATUS_FOR_REMOVED_BUILD = "teamcity.commitStatusPublisher.removedBuild.gitlab.status";
   private static final String REFS_HEADS = "refs/heads/";
   private static final String REFS_TAGS = "refs/tags/";
+  private static final String REFS_GENERIC = "refs/";
   private static final Gson myGson = new Gson();
   private static final GitRepositoryParser VCS_URL_PARSER = new GitRepositoryParser();
 
@@ -322,6 +323,8 @@ class GitlabPublisher extends HttpBasedCommitStatusPublisher<GitlabBuildStatus> 
         ref = ref.substring(REFS_HEADS.length());
       } else if (ref.startsWith(REFS_TAGS)) {
         ref = ref.substring(REFS_TAGS.length());
+      } else if (ref.startsWith(REFS_GENERIC)) {
+        ref = ref.substring(REFS_GENERIC.length());
       } else {
         ref = null;
       }


### PR DESCRIPTION
Currently publishing commit status to GitLab for merge-results fails because the commit hash is not globally "known", whlie GitLab can fix this on their side (since they "know" how to treat merge-result commits once it is initially reported with the relevant ref), this is a proposal to send the ref even for non standard refs

See: https://youtrack.jetbrains.com/issue/TW-78266 for the issue