### PR TITLE
TW-100734 Rename CSP provider field label

### DIFF
--- a/commit-status-publisher-server/src/main/resources/buildServerResources/publisherFeatureHeader.jsp
+++ b/commit-status-publisher-server/src/main/resources/buildServerResources/publisherFeatureHeader.jsp
@@ -154,7 +154,7 @@
   </tr>
   <tr>
     <th>
-      <label for="${constants.publisherIdParam}">Publisher:<l:star/></label>
+      <label for="${constants.publisherIdParam}">VCS Provider:<l:star/></label>
     </th>
     <td>
       <props:selectProperty name="${constants.publisherIdParam}" onchange="PublisherFeature.showPublisherSettings()" enableFilter="true" className="longField" style="width: 28em;">

--- a/kotlin-dsl/CommitStatusPublisher.xml
+++ b/kotlin-dsl/CommitStatusPublisher.xml
@@ -21,7 +21,7 @@
         Set to an empty string to publish status for all VCS roots attached to a build configuration.
       </description>
     </param>
-    <param name="publisherId" dslName="publisher" type="compound" mandatory="true">
+    <param name="publisherId" dslName="vcsProvider" type="compound" mandatory="true">
       <description>
         The type of the VCS provider to which the build status should be published.
       </description>
@@ -471,7 +471,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = github {
+          vcsProvider = github {
             githubUrl = "&lt;GitHub URL, https://api.github.com for github.com>"
             authType = personalToken { // authType = password { ... } to use username and password
               token = "credentialsJSON:*****"
@@ -488,7 +488,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = github {
+          vcsProvider = github {
             githubUrl = "&lt;GitHub URL, https://api.github.com for github.com>"
             authType = vcsRoot()
           }
@@ -503,7 +503,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // A VCS root must be specified to use this authentication type
-          publisher = github {
+          vcsProvider = github {
             githubUrl = "&lt;GitHub URL, https://api.github.com for github.com>"
             authType = storedToken {
               tokenId = "tc_token_id:*****"
@@ -520,7 +520,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // A VCS root must be specified to use this authentication type
-            publisher = github {
+            vcsProvider = github {
               githubUrl = "&lt;GitHub URL, https://api.github.com for github.com>"
               statusCheckName = "Customized GitHub status check name" // optional, can be used for branch protection rules
               authType = storedToken {
@@ -540,7 +540,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = gitlab {
+          vcsProvider = gitlab {
             gitlabApiUrl = "https://&lt;GitLab URL>/api/v4" // optional, the URL will be composed based on the VCS root fetch URL if omitted (https://gitlab.com/api/v4 for gitlab.com)
             accessToken = personalToken { // authType = vcsRoot() to take credentials from the VCS root
               accessToken = "credentialsJSON:*****"
@@ -558,7 +558,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = gitlab {
+          vcsProvider = gitlab {
             jobName = "Customized GitLab status job name" // optional
             gitlabApiUrl = "https://&lt;GitLab URL>/api/v4" // optional, the URL will be composed based on the VCS root fetch URL if omitted (https://gitlab.com/api/v4 for gitlab.com)
             authType = storedToken {
@@ -579,7 +579,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = bitbucketCloud {
+          vcsProvider = bitbucketCloud {
             authType = password { // authType = vcsRoot() to take credentials from the VCS root
               userName = "&lt;username>"
               password = "credentialsJSON:*****"
@@ -597,7 +597,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = bitbucketCloud {
+          vcsProvider = bitbucketCloud {
             buildName = "Customized Bitbucket Cloud status build name" // optional
             authType = storedToken {
               tokenId = "tc_token_id:*****"
@@ -617,7 +617,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = bitbucketServer {
+          vcsProvider = bitbucketServer {
               url = "&lt;Bitbucket Server Base URL>" // optional, the URL will be composed based on the VCS root fetch URL if omitted
               authType = password { // authType = vcsRoot() to take credentials from the VCS root
                 userName = "&lt;username>"
@@ -636,7 +636,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = bitbucketServer {
+          vcsProvider = bitbucketServer {
             buildName = "Customized Bitbucket Server / Data Center status build name" // optional
             url = "&lt;Bitbucket Server Base URL>"
             authType = storedToken {
@@ -656,7 +656,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = azureDevOps {
+          vcsProvider = azureDevOps {
             serverUrl = "&lt;Azure DevOps URL>" // optional
             authType = personalToken {
               accessToken = "tc_token_id:*****"
@@ -675,7 +675,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = azureDevOps {
+          vcsProvider = azureDevOps {
             buildName = "Customized Azure DevOps status build name" // optional
             serverUrl = "&lt;Azure DevOps URL>" // optional
             authType = storedToken {
@@ -696,7 +696,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = swarm {
+          vcsProvider = swarm {
             serverUrl = "&lt;Swarm URL>"
             username = "&lt;username>"
             token = "credentialsJSON:*****"
@@ -713,7 +713,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = gerrit {
+          vcsProvider = gerrit {
             server = "&lt;Gerrit server URL>"
             gerritProject = "&lt;Gerrit project name>"
             label = "&lt;label>" // e.g. Verified
@@ -735,7 +735,7 @@
       <code>
         commitStatusPublisher {
           vcsRootExtId = "${&lt;VCS root object>.id}" // optional, publishes to all attached git VCS roots if omitted
-          publisher = upsource {
+          vcsProvider = upsource {
             serverUrl = "&lt;Upsource URL>"
             projectId = "&lt;Upsource project id>"
             userName = "&lt;username>"


### PR DESCRIPTION
## Summary

Rename the Commit Status Publisher provider selector label from `Publisher` to `VCS Provider`.

## Details

In this form, TeamCity is the actor that publishes commit status updates. The selected value, such as GitHub, is the VCS hosting/provider target rather than the publisher, so the old label was ambiguous.

## Verification

- `TC_LOCAL_REPO=/Users/sugdyzhekov/.m2/repository/TeamCity ./gradlew -p external-repos/commit-status-publisher -PteamcityVersion=2026.2-SNAPSHOT :commit-status-publisher-server:testClasses`
- Confirmed the source and copied build resource both contain `VCS Provider`.

## Mentioned issues

- [TW-100734](https://youtrack.jetbrains.com/issue/TW-100734)
